### PR TITLE
Don't include reason in default HttpMock headers

### DIFF
--- a/googleapiclient/http.py
+++ b/googleapiclient/http.py
@@ -1452,7 +1452,7 @@ class HttpMock(object):
       headers: dict, header to return with response
     """
     if headers is None:
-      headers = {'status': '200 OK'}
+      headers = {'status': '200'}
     if filename:
       f = file(filename, 'r')
       self.data = f.read()

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -999,6 +999,13 @@ class TestResponseCallback(unittest.TestCase):
     self.assertEqual(1, len(responses))
 
 
+class TestHttpMock(unittest.TestCase):
+  def test_default_response_headers(self):
+    http = HttpMock(datafile('zoo.json'))
+    resp, content = http.request("http://example.com")
+    self.assertEqual(resp.status, 200)
+
+
 if __name__ == '__main__':
   logging.getLogger().setLevel(logging.ERROR)
   unittest.main()


### PR DESCRIPTION
As per the [docs](https://developers.google.com/api-client-library/python/guide/mocks), the `MockHttp` object can be created as follows:

`http = HttpMock('books-discovery.json', {'status': '200'})`

The default headers for `HttpMock` currently returns a string, which causes `httplib2` to throw an exception:

`ValueError: invalid literal for int() with base 10: '200 OK'`

The relevant line from `httplib2` can be found here: https://github.com/jcgregorio/httplib2/blob/master/python2/httplib2/__init__.py#L1687