### PR TITLE
MediaIoBaseDownload hangs forever when object to download is smaller than DEFAULT_CHUNK_SIZE

### DIFF
--- a/googleapiclient/http.py
+++ b/googleapiclient/http.py
@@ -559,6 +559,8 @@ class MediaIoBaseDownload(object):
         content_range = resp['content-range']
         length = content_range.rsplit('/', 1)[1]
         self._total_size = int(length)
+      else:
+        self._total_size = int(resp['content-length'])
 
       if self._progress == self._total_size:
         self._done = True

--- a/googleapiclient/http.py
+++ b/googleapiclient/http.py
@@ -559,8 +559,10 @@ class MediaIoBaseDownload(object):
         content_range = resp['content-range']
         length = content_range.rsplit('/', 1)[1]
         self._total_size = int(length)
-      else:
+      elif 'content-length' in resp:
         self._total_size = int(resp['content-length'])
+      else:
+        raise HttpError(resp, content, uri=self._uri)
 
       if self._progress == self._total_size:
         self._done = True


### PR DESCRIPTION
If the file you're downloading via `MediaIoBaseDownload` from Google Cloud Storage is smaller than the `DEFAULT_CHUNK_SIZE` then `self._total_size` was never getting set thus `self._done` was never getting set to `True`.

This would cause code like this to hang forever (even though the file was actually fully downloaded)

    request = farms.animals().get_media(id='super_small_file') # File smaller than DEFAULT_CHUNK_SIZE
    fh = io.FileIO('cow.png', mode='wb')
    downloader = MediaIoBaseDownload(fh, request)

    done = False
    while done is False:
      status, done = downloader.next_chunk() # this done will never be True
      if status:
        print "Download %d%%." % int(status.progress() * 100)
    print "Download Complete!"

I was able to fix this locally with the change in this pull request. That is, if content-range is NOT set in the response headers then set `self._total_size` to the Content Length.