### PR TITLE
Remove a newly-added exception.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: python
+python: 2.7
+sudo: false
+env:
+  matrix:
+  - TOX_ENV=py26
+  - TOX_ENV=py27
+install:
+- pip install tox
+script:
+- tox -e $TOX_ENV
+notifications:
+  email: false

--- a/googleapiclient/http.py
+++ b/googleapiclient/http.py
@@ -561,8 +561,6 @@ class MediaIoBaseDownload(object):
         self._total_size = int(length)
       elif 'content-length' in resp:
         self._total_size = int(resp['content-length'])
-      else:
-        raise HttpError(resp, content, uri=self._uri)
 
       if self._progress == self._total_size:
         self._done = True


### PR DESCRIPTION
It turns out that the same code in `http.py` is used for processing both (1)
the initial response and redirect and (2) the replies containing actual bytes
for download. This means that the new exception we added for (2) leads to
problems in (1).