### PR TITLE
Now uses python2.6+ style 'except'.

### DIFF
--- a/googleapiclient/discovery.py
+++ b/googleapiclient/discovery.py
@@ -205,7 +205,7 @@ def build(serviceName,
 
   try:
     service = json.loads(content)
-  except ValueError, e:
+  except ValueError as e:
     logger.error('Failed to parse as JSON: ' + content)
     raise InvalidJsonError()
 

--- a/googleapiclient/http.py
+++ b/googleapiclient/http.py
@@ -1330,7 +1330,7 @@ class BatchHttpRequest(object):
         if resp.status >= 300:
           raise HttpError(resp, content, uri=request.uri)
         response = request.postproc(resp, content)
-      except HttpError, e:
+      except HttpError as e:
         exception = e
 
       if callback is not None:

--- a/samples/analytics/core_reporting_v3_reference.py
+++ b/samples/analytics/core_reporting_v3_reference.py
@@ -84,11 +84,11 @@ def main(argv):
     results = get_api_query(service, flags.table_id).execute()
     print_results(results)
 
-  except TypeError, error:
+  except TypeError as error:
     # Handle errors in constructing a query.
     print ('There was an error in constructing your query : %s' % error)
 
-  except HttpError, error:
+  except HttpError as error:
     # Handle API errors.
     print ('Arg, there was an API error : %s : %s' %
            (error.resp.status, error._get_reason()))

--- a/samples/analytics/hello_analytics_api_v3.py
+++ b/samples/analytics/hello_analytics_api_v3.py
@@ -66,11 +66,11 @@ def main(argv):
       results = get_top_keywords(service, first_profile_id)
       print_results(results)
 
-  except TypeError, error:
+  except TypeError as error:
     # Handle errors in constructing a query.
     print ('There was an error in constructing your query : %s' % error)
 
-  except HttpError, error:
+  except HttpError as error:
     # Handle API errors.
     print ('Arg, there was an API error : %s : %s' %
            (error.resp.status, error._get_reason()))

--- a/samples/analytics/management_v3_reference.py
+++ b/samples/analytics/management_v3_reference.py
@@ -71,11 +71,11 @@ def main(argv):
   try:
     traverse_hiearchy(service)
 
-  except TypeError, error:
+  except TypeError as error:
     # Handle errors in constructing a query.
     print ('There was an error in constructing your query : %s' % error)
 
-  except HttpError, error:
+  except HttpError as error:
     # Handle API errors.
     print ('Arg, there was an API error : %s : %s' %
            (error.resp.status, error._get_reason()))

--- a/samples/coordinate/coordinate.py
+++ b/samples/coordinate/coordinate.py
@@ -91,7 +91,7 @@ def main(argv):
 
     pprint.pprint(update_result)
 
-  except AccessTokenRefreshError, e:
+  except AccessTokenRefreshError as e:
     print ('The credentials have been revoked or expired, please re-run'
       'the application to re-authorize')
 

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -388,7 +388,7 @@ class DiscoveryFromHttp(unittest.TestCase):
       zoo = build('zoo', 'v1', http=http, developerKey='foo',
                   discoveryServiceUrl='http://example.com')
       self.fail('Should have raised an exception.')
-    except HttpError, e:
+    except HttpError as e:
       self.assertEqual(e.uri, 'http://example.com?userIp=10.0.0.1')
 
   def test_userip_missing_is_not_added_to_discovery_uri(self):
@@ -401,7 +401,7 @@ class DiscoveryFromHttp(unittest.TestCase):
       zoo = build('zoo', 'v1', http=http, developerKey=None,
                   discoveryServiceUrl='http://example.com')
       self.fail('Should have raised an exception.')
-    except HttpError, e:
+    except HttpError as e:
       self.assertEqual(e.uri, 'http://example.com')
 
 
@@ -415,28 +415,28 @@ class Discovery(unittest.TestCase):
     try:
       plus.activities().list()
       self.fail()
-    except TypeError, e:
+    except TypeError as e:
       self.assertTrue('Missing' in str(e))
 
     # Missing required parameters even if supplied as None.
     try:
       plus.activities().list(collection=None, userId=None)
       self.fail()
-    except TypeError, e:
+    except TypeError as e:
       self.assertTrue('Missing' in str(e))
 
     # Parameter doesn't match regex
     try:
       plus.activities().list(collection='not_a_collection_name', userId='me')
       self.fail()
-    except TypeError, e:
+    except TypeError as e:
       self.assertTrue('not an allowed value' in str(e))
 
     # Unexpected parameter
     try:
       plus.activities().list(flubber=12)
       self.fail()
-    except TypeError, e:
+    except TypeError as e:
       self.assertTrue('unexpected' in str(e))
 
   def _check_query_types(self, request):
@@ -805,7 +805,7 @@ class Discovery(unittest.TestCase):
     try:
       request.execute(http=http)
       self.fail('Should have raised ResumableUploadError.')
-    except ResumableUploadError, e:
+    except ResumableUploadError as e:
       self.assertEqual(400, e.resp.status)
 
   def test_resumable_media_fail_unknown_response_code_subsequent_request(self):
@@ -905,7 +905,7 @@ class Discovery(unittest.TestCase):
 
       try:
         body = request.execute(http=http)
-      except HttpError, e:
+      except HttpError as e:
         self.assertEqual('01234', e.content)
 
     except ImportError:
@@ -1060,7 +1060,7 @@ class Discovery(unittest.TestCase):
     try:
       # Should resume the upload by first querying the status of the upload.
       request.next_chunk(http=http)
-    except HttpError, e:
+    except HttpError as e:
       expected = {
           'Content-Range': 'bytes */14',
           'content-length': '0'

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -796,7 +796,7 @@ class TestBatch(unittest.TestCase):
     try:
       batch.execute(http=http)
       self.fail('Should raise exception')
-    except BatchError, e:
+    except BatchError as e:
       boundary, _ = e.content.split(None, 1)
       self.assertEqual('--', boundary[:2])
       parts = e.content.split(boundary)

--- a/tests/test_json_model.py
+++ b/tests/test_json_model.py
@@ -152,7 +152,7 @@ class Model(unittest.TestCase):
     try:
       content = model.response(resp, content)
       self.fail('Should have thrown an exception')
-    except HttpError, e:
+    except HttpError as e:
       self.assertTrue('not authorized' in str(e))
 
     resp['content-type'] = 'application/json'
@@ -160,7 +160,7 @@ class Model(unittest.TestCase):
     try:
       content = model.response(resp, content)
       self.fail('Should have thrown an exception')
-    except HttpError, e:
+    except HttpError as e:
       self.assertTrue('not authorized' in str(e))
 
   def test_good_response(self):

--- a/tests/test_mocks.py
+++ b/tests/test_mocks.py
@@ -140,7 +140,7 @@ class Mocks(unittest.TestCase):
     try:
       activity = plus.activities().list(collection='public', userId='me').execute()
       self.fail('An exception should have been thrown')
-    except HttpError, e:
+    except HttpError as e:
       self.assertEqual('{}', e.content)
       self.assertEqual(500, e.resp.status)
       self.assertEqual('Server Error', e.resp.reason)


### PR DESCRIPTION
This is one teeny-tiny step towards python3 support.

Since python2.5 is not supported, and python3 is going to be supported, why not start using modern-style 'except'?

Super simple and safe step towards py3.