### PR TITLE
Removed unneeded/unused line of code

### DIFF
--- a/samples/audit/audit.py
+++ b/samples/audit/audit.py
@@ -50,8 +50,6 @@ def main(argv):
       argv, 'audit', 'v1', __doc__, __file__,
       scope='https://www.googleapis.com/auth/apps/reporting/audit.readonly')
 
-  service = build('audit', 'v1', http=http)
-
   try:
     activities = service.activities()
 


### PR DESCRIPTION
The call to build(api, version, http) to setup the service stub is unneeded since the call to sample_tools.init above does that for the sample.  Plus the build function was not imported from apiclient.discovery which causes this sample to not work at all.