### PR TITLE
py3 errors: decode `bytes` input before passing it to json.loads

### DIFF
--- a/googleapiclient/errors.py
+++ b/googleapiclient/errors.py
@@ -44,7 +44,12 @@ class HttpError(Error):
     """Calculate the reason for the error from the response content."""
     reason = self.resp.reason
     try:
-      data = json.loads(self.content)
+      # turn content into a unicode string, this is required on python 3
+      if isinstance(self.content, bytes):
+        content = self.content.decode('utf-8')
+      else:
+        content = self.content
+      data = json.loads(content)
       reason = data['error']['message']
     except (ValueError, KeyError):
       pass

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -71,6 +71,17 @@ class Error(unittest.TestCase):
     error = HttpError(resp, content)
     self.assertEqual(str(error), '<HttpError 400 "Failed">')
 
+  def test_json_bytes_body(self):
+    """Test a nicely formed, expected error response when the body is `bytes`."""
+    resp, content = fake_response(JSON_ERROR_CONTENT,
+        {'status':'400', 'content-type': 'application/json'},
+        reason='Failed')
+    # this will turn the body into `bytes` which is different from `str` on
+    # python 3 and is what we usually get from the network
+    content = content.encode('utf-8')
+    error = HttpError(resp, content, uri='http://example.org')
+    self.assertEqual(str(error), '<HttpError 400 when requesting http://example.org returned "country is required">')
+
   def test_with_uri(self):
     """Test handling of passing in the request uri."""
     resp, content = fake_response('{',


### PR DESCRIPTION
Http response contents use `bytes` type in Python 3.  json.loads requires
its input to be `str` so utf-8 decode the input before trying to load it.