### PR TITLE
Fix unicode issues in HttpError and BatchHttpRequest

### DIFF
--- a/googleapiclient/errors.py
+++ b/googleapiclient/errors.py
@@ -37,6 +37,8 @@ class HttpError(Error):
   @util.positional(3)
   def __init__(self, resp, content, uri=None):
     self.resp = resp
+    if not isinstance(content, bytes):
+        raise TypeError("HTTP content should be bytes")
     self.content = content
     self.uri = uri
 
@@ -44,7 +46,7 @@ class HttpError(Error):
     """Calculate the reason for the error from the response content."""
     reason = self.resp.reason
     try:
-      data = json.loads(self.content)
+      data = json.loads(self.content.decode('utf-8'))
       reason = data['error']['message']
     except (ValueError, KeyError):
       pass

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1048,7 +1048,7 @@ class Discovery(unittest.TestCase):
           'Content-Range': 'bytes */14',
           'content-length': '0'
           }
-      self.assertEqual(expected, json.loads(e.content),
+      self.assertEqual(expected, json.loads(e.content.decode('utf-8')),
         'Should send an empty body when requesting the current upload status.')
 
   def test_pickle(self):
@@ -1186,7 +1186,7 @@ class MediaGet(unittest.TestCase):
       ({'status': '200'}, 'standing in for media'),
       ])
     response = request.execute(http=http)
-    self.assertEqual('standing in for media', response)
+    self.assertEqual(b'standing in for media', response)
 
 
 if __name__ == '__main__':

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -28,7 +28,7 @@ import httplib2
 from googleapiclient.errors import HttpError
 
 
-JSON_ERROR_CONTENT = """
+JSON_ERROR_CONTENT = b"""
 {
  "error": {
   "errors": [
@@ -65,7 +65,7 @@ class Error(unittest.TestCase):
 
   def test_bad_json_body(self):
     """Test handling of bodies with invalid json."""
-    resp, content = fake_response('{',
+    resp, content = fake_response(b'{',
         { 'status':'400', 'content-type': 'application/json'},
         reason='Failed')
     error = HttpError(resp, content)
@@ -73,7 +73,7 @@ class Error(unittest.TestCase):
 
   def test_with_uri(self):
     """Test handling of passing in the request uri."""
-    resp, content = fake_response('{',
+    resp, content = fake_response(b'{',
         {'status':'400', 'content-type': 'application/json'},
         reason='Failure')
     error = HttpError(resp, content, uri='http://example.org')
@@ -81,7 +81,7 @@ class Error(unittest.TestCase):
 
   def test_missing_message_json_body(self):
     """Test handling of bodies with missing expected 'message' element."""
-    resp, content = fake_response('{}',
+    resp, content = fake_response(b'{}',
         {'status':'400', 'content-type': 'application/json'},
         reason='Failed')
     error = HttpError(resp, content)
@@ -89,12 +89,12 @@ class Error(unittest.TestCase):
 
   def test_non_json(self):
     """Test handling of non-JSON bodies"""
-    resp, content = fake_response('}NOT OK', {'status':'400'})
+    resp, content = fake_response(b'}NOT OK', {'status':'400'})
     error = HttpError(resp, content)
     self.assertEqual(str(error), '<HttpError 400 "Ok">')
 
   def test_missing_reason(self):
     """Test an empty dict with a missing resp.reason."""
-    resp, content = fake_response('}NOT OK', {'status': '400'}, reason=None)
+    resp, content = fake_response(b'}NOT OK', {'status': '400'}, reason=None)
     error = HttpError(resp, content)
     self.assertEqual(str(error), '<HttpError 400 "">')

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -460,7 +460,7 @@ Content-Length: 14
 ETag: "etag/pony"\r\n\r\n{"answer": 42}"""
 
 
-BATCH_RESPONSE = """--batch_foobarbaz
+BATCH_RESPONSE = b"""--batch_foobarbaz
 Content-Type: application/http
 Content-Transfer-Encoding: binary
 Content-ID: <randomness+1>
@@ -482,7 +482,7 @@ ETag: "etag/sheep"\r\n\r\n{"baz": "qux"}
 --batch_foobarbaz--"""
 
 
-BATCH_ERROR_RESPONSE = """--batch_foobarbaz
+BATCH_ERROR_RESPONSE = b"""--batch_foobarbaz
 Content-Type: application/http
 Content-Transfer-Encoding: binary
 Content-ID: <randomness+1>
@@ -518,7 +518,7 @@ ETag: "etag/sheep"\r\n\r\n{
 --batch_foobarbaz--"""
 
 
-BATCH_RESPONSE_WITH_401 = """--batch_foobarbaz
+BATCH_RESPONSE_WITH_401 = b"""--batch_foobarbaz
 Content-Type: application/http
 Content-Transfer-Encoding: binary
 Content-ID: <randomness+1>
@@ -541,7 +541,7 @@ ETag: "etag/sheep"\r\n\r\n{"baz": "qux"}
 --batch_foobarbaz--"""
 
 
-BATCH_SINGLE_RESPONSE = """--batch_foobarbaz
+BATCH_SINGLE_RESPONSE = b"""--batch_foobarbaz
 Content-Type: application/http
 Content-Transfer-Encoding: binary
 Content-ID: <randomness+1>
@@ -928,7 +928,7 @@ class TestRequestUriTooLong(unittest.TestCase):
 
     # Query parameters should be sent in the body.
     response = req.execute()
-    self.assertEqual('q=' + 'a' * MAX_URI_LENGTH + '%3F%26', response)
+    self.assertEqual(b'q=' + b'a' * MAX_URI_LENGTH + b'%3F%26', response)
 
     # Extra headers should be set.
     response = req.execute()

--- a/tests/test_json_model.py
+++ b/tests/test_json_model.py
@@ -150,7 +150,7 @@ class Model(unittest.TestCase):
     model = JsonModel(data_wrapper=False)
     resp = httplib2.Response({'status': '401'})
     resp.reason = 'Unauthorized'
-    content = '{"error": {"message": "not authorized"}}'
+    content = b'{"error": {"message": "not authorized"}}'
 
     try:
       content = model.response(resp, content)

--- a/tests/test_mocks.py
+++ b/tests/test_mocks.py
@@ -134,7 +134,7 @@ class Mocks(unittest.TestCase):
   def test_errors(self):
     errorResponse = httplib2.Response({'status': 500, 'reason': 'Server Error'})
     requestBuilder = RequestMockBuilder({
-        'plus.activities.list': (errorResponse, '{}')
+        'plus.activities.list': (errorResponse, b'{}')
         })
     plus = build('plus', 'v1', http=self.http, requestBuilder=requestBuilder)
 
@@ -142,7 +142,7 @@ class Mocks(unittest.TestCase):
       activity = plus.activities().list(collection='public', userId='me').execute()
       self.fail('An exception should have been thrown')
     except HttpError as e:
-      self.assertEqual('{}', e.content)
+      self.assertEqual(b'{}', e.content)
       self.assertEqual(500, e.resp.status)
       self.assertEqual('Server Error', e.resp.reason)
 


### PR DESCRIPTION
1) HttpError parses http response by json.loads. It accepts only
unicode on PY3 while response is bytes. So decode response first.

2) BatchHttpRequest uses email.parser.FeedParser. It accepts only
unicode on PY3, too. So encode parsed response to emulate normal
http response.