### PR TITLE
Adding coveralls integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,7 @@
+[report]
+omit = */samples/*
+exclude_lines =
+    # Re-enable the standard pragma
+    pragma: NO COVER
+    # Ignore debug-only repr
+    def __repr__

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@ dist/
 
 # Test files
 .tox/
+
+# Coverage files
+.coverage
+coverage.xml
+nosetests.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,10 @@ env:
   - TOX_ENV=py34
 install:
 - pip install tox
+- pip install coveralls
 script:
 - tox -e $TOX_ENV
+after_success:
+  coveralls
 notifications:
   email: false

--- a/tox.ini
+++ b/tox.ini
@@ -9,5 +9,6 @@ deps = keyring
        django
        webtest
        nose
+       coverage>=3.6,<3.99
        unittest2
-commands = nosetests
+commands = nosetests --with-coverage --cover-package=googleapiclient --nocapture --cover-erase --cover-tests --cover-branches --cover-min-percentage=85

--- a/tox.ini
+++ b/tox.ini
@@ -10,16 +10,4 @@ deps = keyring
        webtest
        nose
        unittest2
-setenv = PYTHONPATH=../google_appengine
-
-[testenv:py26]
-commands = nosetests --ignore-files=test_oauth2client_appengine\.py
-
-[testenv:py27]
-commands = nosetests
-
-[testenv:py33]
-commands = nosetests
-
-[testenv:py34]
 commands = nosetests


### PR DESCRIPTION
Run coverage with all tests and send results to coveralls.io.

This was added to oauth2client and I figured we should add it here as well.