### PR TITLE
Python 3 compat improvements

### DIFF
--- a/googleapiclient/discovery.py
+++ b/googleapiclient/discovery.py
@@ -201,10 +201,8 @@ def build(serviceName,
   if resp.status >= 400:
     raise HttpError(resp, content, uri=requested_url)
 
-  try:
+  if isinstance(content, bytes):
     content = content.decode('utf-8')
-  except AttributeError:
-    pass
 
   try:
     service = json.loads(content)

--- a/googleapiclient/model.py
+++ b/googleapiclient/model.py
@@ -258,10 +258,8 @@ class JsonModel(BaseModel):
     return json.dumps(body_value)
 
   def deserialize(self, content):
-    try:
-        content = content.decode('utf-8')
-    except AttributeError:
-        pass
+    if isinstance(content, bytes):
+      content = content.decode('utf-8')
     body = json.loads(content)
     if self._data_wrapper and isinstance(body, dict) and 'data' in body:
       body = body['data']

--- a/tests/data/zoo.json
+++ b/tests/data/zoo.json
@@ -288,10 +288,10 @@
   },
   "global": {
    "resources": {
-    "print": {
+    "from": {
      "methods": {
       "assert": {
-       "path": "global/print/assert",
+       "path": "global/from/assert",
        "id": "zoo.animals.mine",
        "httpMethod": "GET",
        "parameters": {

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -568,14 +568,13 @@ class Discovery(unittest.TestCase):
     q = parse_qs(parsed[4])
     self.assertEqual(q['max-results'], ['5'])
 
-  @unittest.skipIf(six.PY3, 'print is not a reserved name in Python 3')
   def test_methods_with_reserved_names(self):
     self.http = HttpMock(datafile('zoo.json'), {'status': '200'})
     zoo = build('zoo', 'v1', http=self.http)
     self.assertTrue(getattr(zoo, 'animals'))
-    request = zoo.global_().print_().assert_(max_results="5")
+    request = zoo.global_().from_().assert_(max_results="5")
     parsed = urlparse(request.uri)
-    self.assertEqual(parsed[2], '/zoo/v1/global/print/assert')
+    self.assertEqual(parsed[2], '/zoo/v1/global/from/assert')
 
   def test_top_level_functions(self):
     self.http = HttpMock(datafile('zoo.json'), {'status': '200'})


### PR DESCRIPTION
* tests: use a different name for reserved name test and enable on py3
* json input: don't try to utf-8 decode everything unconditionally