### PR TITLE
be completed if the HTTP status 200 is responded for range request.

### DIFF
--- a/googleapiclient/http.py
+++ b/googleapiclient/http.py
@@ -566,7 +566,7 @@ class MediaIoBaseDownload(object):
       elif 'content-length' in resp:
         self._total_size = int(resp['content-length'])
 
-      if self._progress == self._total_size:
+      if self._progress == self._total_size or resp.status == 200:
         self._done = True
       return MediaDownloadProgress(self._progress, self._total_size), self._done
     else:


### PR DESCRIPTION
The current implementation is checking for transferred progress of total size to completion judgment.
will prevent an infinite loop of the case that are not contain both "Content-Range" and "Content-Length" is  in the response.