### PR TITLE
infinite loop when range request has been ignored and no length information in response header

### DIFF
--- a/googleapiclient/http.py
+++ b/googleapiclient/http.py
@@ -565,6 +565,8 @@ class MediaIoBaseDownload(object):
         self._total_size = int(length)
       elif 'content-length' in resp:
         self._total_size = int(resp['content-length'])
+      elif resp.status == 200:
+        self._done = True
 
       if self._progress == self._total_size:
         self._done = True

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -348,6 +348,29 @@ class TestMediaIoBaseDownload(unittest.TestCase):
     self.assertEqual(5, download._progress)
     self.assertEqual(5, download._total_size)
 
+  def test_media_io_base_download_handle_range_request_ignored(self):
+    self.request.http = HttpMockSequence([
+      ({'status': '200'}, b'12345'),
+    ])
+
+    download = MediaIoBaseDownload(
+        fd=self.fd, request=self.request, chunksize=6)
+
+    self.assertEqual(self.fd, download._fd)
+    self.assertEqual(6, download._chunksize)
+    self.assertEqual(0, download._progress)
+    self.assertEqual(None, download._total_size)
+    self.assertEqual(False, download._done)
+    self.assertEqual(self.request.uri, download._uri)
+
+    status, done = download.next_chunk()
+
+    self.assertEqual(self.fd.getvalue(), b'12345')
+    self.assertEqual(True, done)
+    self.assertEqual(5, download._progress)
+    self.assertEqual(None, download._total_size)
+    self.assertEqual(5, status.resumable_progress)
+
   def test_media_io_base_download_handle_redirects(self):
     self.request.http = HttpMockSequence([
       ({'status': '200',


### PR DESCRIPTION
I've been experienced both "Content-Length" and "Content-Range" is not in response while download from Google Cloud Storage.

Current implementation is checked by total length. but sometime less.
set "done" flag by HTTP Status 200 (not 206 Partial) is enough i guess.


