### PR TITLE
Fix error reporting in python 3

### DIFF
--- a/googleapiclient/http.py
+++ b/googleapiclient/http.py
@@ -726,6 +726,8 @@ class HttpRequest(object):
     for callback in self.response_callbacks:
       callback(resp)
     if resp.status >= 300:
+      if six.PY3:
+        content = content.decode()
       raise HttpError(resp, content, uri=self.uri)
     return self.postproc(resp, content)
 


### PR DESCRIPTION
The content consists of bytes in python 3 and the HttpError object thinks its a string when it tries to decode it. I'm not sure if this is the best place to fix it, since it could also be fixed in the HttpError object itself.