### PR TITLE
Minor Markdown Fix

### DIFF
--- a/samples/adexchangebuyer/README.md
+++ b/samples/adexchangebuyer/README.md
@@ -1,5 +1,5 @@
-Where are the samples?
-=======================================================
+# Where are the samples?
+
 The DoubleClick Ad Exchange Buyer REST API samples are now hosted separately
 from the client library project. You can find them
-[here.](https://github.com/googleads/googleads-adxbuyer-examples/tree/master/python)
+[here](https://github.com/googleads/googleads-adxbuyer-examples/tree/master/python).

--- a/samples/dfareporting/README.md
+++ b/samples/dfareporting/README.md
@@ -1,5 +1,5 @@
-Where are the samples?
-=======================================================
+# Where are the samples?
+
 The DoubleClick for Advertisers Reporting API samples are now hosted separately
 from the client library project. You can find them
-[here.](https://github.com/googleads/googleads-dfa-reporting-samples)
+[here](https://github.com/googleads/googleads-dfa-reporting-samples).


### PR DESCRIPTION
Proposal
===

Update the copyright years on some files to 2015. Update some .md files to use better header formatting.

Reasoning
===

The nature of this PR should be self-explanatory but, just incase, we are currently in the year 2015 and the copyright years should reflect such as this is still an active project. The header style change in the .md files preserves the intended visual but uses a more easily editable method (no one wants to keep typing === under every letter of the header).