### PR TITLE
Stop stripping newlines from batch requests

### DIFF
--- a/googleapiclient/http.py
+++ b/googleapiclient/http.py
@@ -1120,10 +1120,6 @@ class BatchHttpRequest(object):
     g.flatten(msg, unixfrom=False)
     body = fp.getvalue()
 
-    # Strip off the \n\n that the MIME lib tacks onto the end of the payload.
-    if request.body is None:
-      body = body[:-2]
-
     return status_line + body
 
   def _deserialize_response(self, payload):

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -453,6 +453,11 @@ MIME-Version: 1.0
 Host: www.googleapis.com
 content-length: 0\r\n\r\n"""
 
+NO_BODY_EXPECTED_GET = """GET /someapi/v1/collection/?foo=bar HTTP/1.1
+Content-Type: application/json
+MIME-Version: 1.0
+Host: www.googleapis.com\r\n\r\n"""
+
 
 RESPONSE = """HTTP/1.1 200 OK
 Content-Type: application/json
@@ -710,6 +715,20 @@ class TestBatch(unittest.TestCase):
         resumable=None)
     s = batch._serialize_request(request).splitlines()
     self.assertEqual(NO_BODY_EXPECTED.splitlines(), s)
+
+  def test_serialize_get_request_no_body(self):
+    batch = BatchHttpRequest()
+    request = HttpRequest(
+        None,
+        None,
+        'https://www.googleapis.com/someapi/v1/collection/?foo=bar',
+        method='GET',
+        body=None,
+        headers={'content-type': 'application/json'},
+        methodId=None,
+        resumable=None)
+    s = batch._serialize_request(request).splitlines()
+    self.assertEqual(NO_BODY_EXPECTED_GET.splitlines(), s)
 
   def test_deserialize_response(self):
     batch = BatchHttpRequest()


### PR DESCRIPTION
When forming a multipart/mixed HTTP request like the ones created using
the BatchHttpRequest object, the request is supposed to include two
trailing newlines to signify:

1. The termination of the HTTP headers for each wrapped request.
2. The empty body of the wrapped request.

Without this change some implementations of API servers were rejecting
requests generated by this client.  Specifically requests which had an
empty wrapped request body.