### PR TITLE
Making http parameter in discovery.build_from_document optional.

### DIFF
--- a/googleapiclient/discovery.py
+++ b/googleapiclient/discovery.py
@@ -254,6 +254,9 @@ def build_from_document(
     A Resource object with methods for interacting with the service.
   """
 
+  if http is None:
+    http = httplib2.Http()
+
   # future is no longer used.
   future = {}
 

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -366,6 +366,17 @@ class DiscoveryFromDocument(unittest.TestCase):
     plus = build_from_document(discovery, base=base)
     self.assertEquals("https://www.googleapis.com/plus/v1/", plus._baseUrl)
 
+  def test_building_with_optional_http(self):
+    discovery = open(datafile('plus.json')).read()
+    plus = build_from_document(discovery, base="https://www.googleapis.com/")
+    self.assertTrue(isinstance(plus._http, httplib2.Http))
+
+  def test_building_with_explicit_http(self):
+    http = HttpMock()
+    discovery = open(datafile('plus.json')).read()
+    plus = build_from_document(
+      discovery, base="https://www.googleapis.com/", http=http)
+    self.assertEquals(plus._http, http)
 
 class DiscoveryFromHttp(unittest.TestCase):
   def setUp(self):


### PR DESCRIPTION
discovery.build()'s http parameter is optional, but if you call build_from_document directly it doesn't handle the case where http is None. Fixed that so now you can call ``discovery.build_from_document(doc, credentials=credentials)``.