### PR TITLE
Stored Reason on HttpErrors

### DIFF
--- a/googleapiclient/errors.py
+++ b/googleapiclient/errors.py
@@ -40,7 +40,7 @@ class HttpError(Error):
     if not isinstance(content, bytes):
         raise TypeError("HTTP content should be bytes")
     self.content = content
-    self.reason = _get_reason().strip()
+    self.reason = self._get_reason().strip()
     self.uri = uri
 
   def _get_reason(self):

--- a/googleapiclient/errors.py
+++ b/googleapiclient/errors.py
@@ -51,16 +51,15 @@ class HttpError(Error):
       reason = data['error']['message']
     except (ValueError, KeyError):
       pass
-    if reason is None:
-      reason = ''
     return reason
 
   def __repr__(self):
     if self.uri:
       return '<HttpError %s when requesting %s returned "%s">' % (
-          self.resp.status, self.uri, self.reason)
+          self.resp.status, self.uri, self.reason if self.reason else '')
     else:
-      return '<HttpError %s "%s">' % (self.resp.status, self.reason)
+      return '<HttpError %s "%s">' % (self.resp.status,
+                                      self.reason if self.reason else '')
 
   __str__ = __repr__
 

--- a/googleapiclient/errors.py
+++ b/googleapiclient/errors.py
@@ -40,7 +40,7 @@ class HttpError(Error):
     if not isinstance(content, bytes):
         raise TypeError("HTTP content should be bytes")
     self.content = content
-    self.reason = self._get_reason().strip()
+    self.reason = self._get_reason()
     self.uri = uri
 
   def _get_reason(self):
@@ -48,7 +48,7 @@ class HttpError(Error):
     reason = self.resp.reason
     try:
       data = json.loads(self.content.decode('utf-8'))
-      reason = data['error']['message']
+      reason = data['error']['message'].strip()
     except (ValueError, KeyError):
       pass
     return reason

--- a/googleapiclient/errors.py
+++ b/googleapiclient/errors.py
@@ -40,6 +40,7 @@ class HttpError(Error):
     if not isinstance(content, bytes):
         raise TypeError("HTTP content should be bytes")
     self.content = content
+    self.reason = _get_reason().strip()
     self.uri = uri
 
   def _get_reason(self):
@@ -57,9 +58,9 @@ class HttpError(Error):
   def __repr__(self):
     if self.uri:
       return '<HttpError %s when requesting %s returned "%s">' % (
-          self.resp.status, self.uri, self._get_reason().strip())
+          self.resp.status, self.uri, self.reason)
     else:
-      return '<HttpError %s "%s">' % (self.resp.status, self._get_reason())
+      return '<HttpError %s "%s">' % (self.resp.status, self.reason)
 
   __str__ = __repr__
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -77,6 +77,7 @@ class Error(unittest.TestCase):
         {'status':'400', 'content-type': 'application/json'},
         reason='Failure')
     error = HttpError(resp, content, uri='http://example.org')
+    self.assertEqual(error.reason, "Failure")
     self.assertEqual(str(error), '<HttpError 400 when requesting http://example.org returned "Failure">')
 
   def test_missing_message_json_body(self):
@@ -97,4 +98,5 @@ class Error(unittest.TestCase):
     """Test an empty dict with a missing resp.reason."""
     resp, content = fake_response(b'}NOT OK', {'status': '400'}, reason=None)
     error = HttpError(resp, content)
+    self.assertIsNone(error.reason)
     self.assertEqual(str(error), '<HttpError 400 "">')


### PR DESCRIPTION
In the case where there are multiple reason strings for HttpErrors with the same code, end users may want to filter errors based on the reason string. 