### PR TITLE
Discovery: Treat empty nextPageToken field the same as it not existing

### DIFF
--- a/googleapiclient/discovery.py
+++ b/googleapiclient/discovery.py
@@ -857,7 +857,7 @@ Returns:
     # Retrieve nextPageToken from previous_response
     # Use as pageToken in previous_request to create new request.
 
-    if 'nextPageToken' not in previous_response:
+    if 'nextPageToken' not in previous_response or not previous_response['nextPageToken']:
       return None
 
     request = copy.copy(previous_request)

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1183,6 +1183,14 @@ class Next(unittest.TestCase):
     request = tasks.tasklists().list()
     self.assertEqual(None, tasks.tasklists().list_next(request, {}))
 
+  def test_next_successful_none_on_empty_page_token(self):
+    self.http = HttpMock(datafile('tasks.json'), {'status': '200'})
+    tasks = build('tasks', 'v1', http=self.http)
+    request = tasks.tasklists().list()
+    next_request = tasks.tasklists().list_next(
+        request, {'nextPageToken': ''})
+    self.assertEqual(None, next_request)
+
   def test_next_successful_with_next_page_token(self):
     self.http = HttpMock(datafile('tasks.json'), {'status': '200'})
     tasks = build('tasks', 'v1', http=self.http)


### PR DESCRIPTION
Sending nextPageToken out with an empty string to Google's DFA API will
raise a 500 error. This commit treats an empty nextPageToken field the
same as it not existing at all so that method.list_next() will not
attempt to retrieve a non-existent page of results.