### PR TITLE
return if the batch is empty

### DIFF
--- a/googleapiclient/http.py
+++ b/googleapiclient/http.py
@@ -1288,6 +1288,9 @@ class BatchHttpRequest(object):
       httplib2.HttpLib2Error if a transport error has occured.
       googleapiclient.errors.BatchError if the response is the wrong format.
     """
+    # If we have no requests return
+    if len(self._order) == 0:
+      return None
 
     # If http is not supplied use the first valid one given in the requests.
     if http is None:

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -766,6 +766,11 @@ class TestBatch(unittest.TestCase):
     self.request1.resumable = upload
     self.assertRaises(BatchError, batch.add, self.request1, request_id='1')
 
+  def test_execute_empty_batch_no_http(self):
+    batch = BatchHttpRequest()
+    ret = batch.execute()
+    self.assertEqual(None, ret)
+
   def test_execute(self):
     batch = BatchHttpRequest()
     callbacks = Callbacks()


### PR DESCRIPTION
The batch execute when not given an http object will look into the given requests. If no request was given, it will raise a `ValueError("Missing a valid http object.")`.