### PR TITLE
Upgrade django sample project to use render method

### DIFF
--- a/samples/django_sample/plus/views.py
+++ b/samples/django_sample/plus/views.py
@@ -8,7 +8,7 @@ from django.core.urlresolvers import reverse
 from django.http import HttpResponse
 from django.http import HttpResponseBadRequest
 from django.http import HttpResponseRedirect
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 from django_sample.plus.models import CredentialsModel
 from django_sample import settings
 from oauth2client import xsrfutil
@@ -45,7 +45,7 @@ def index(request):
                                    userId='me').execute()
     logging.info(activitylist)
 
-    return render_to_response('plus/welcome.html', {
+    return render(request, 'plus/welcome.html', {
                 'activitylist': activitylist,
                 })
 


### PR DESCRIPTION
Use render method to render the view as it is a replacement for 
render_to_response.

Exclude backward compatibility for render_to_response method as 
developers using it are likely to be on one of the latest versions of 
Django that has support for render method. Therefore, render_to_response
support may be excluded altogether from this sample project. 
