### PR TITLE
Force HttpMock to read content from file as bytes

### DIFF
--- a/googleapiclient/http.py
+++ b/googleapiclient/http.py
@@ -1463,7 +1463,7 @@ class HttpMock(object):
     if headers is None:
       headers = {'status': '200'}
     if filename:
-      f = open(filename, 'r')
+      f = open(filename, 'rb')
       self.data = f.read()
       f.close()
     else:

--- a/tests/data/bad_request.json
+++ b/tests/data/bad_request.json
@@ -1,0 +1,13 @@
+{
+ "error": {
+  "errors": [
+   {
+    "domain": "usageLimits",
+    "reason": "keyInvalid",
+    "message": "Bad Request"
+   }
+  ],
+  "code": 400,
+  "message": "Bad Request"
+ }
+}

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1010,6 +1010,17 @@ class TestHttpMock(unittest.TestCase):
     resp, content = http.request("http://example.com")
     self.assertEqual(resp.status, 200)
 
+  def test_error_response(self):
+    http = HttpMock(datafile('bad_request.json'), {'status': '400'})
+    model = JsonModel()
+    request = HttpRequest(
+        http,
+        model.response,
+        'https://www.googleapis.com/someapi/v1/collection/?foo=bar',
+        method='GET',
+        headers={})
+    self.assertRaises(HttpError, request.execute)
+
 
 if __name__ == '__main__':
   logging.getLogger().setLevel(logging.ERROR)


### PR DESCRIPTION
Fixes #124.

I decided to write the test for the functionality I was actually trying to use, and which was previously not covered by tests: using ``HttpMock`` specifically to mock error responses. The side effect is that it exposes how ``HttpMock`` was not not reading content as bytes on Python 3 and causing a confusing exception to be thrown.

I think the fix speaks for itself...