### PR TITLE
Implemented automatic caching for the discovery documents.

### DIFF
--- a/googleapiclient/discovery_cache/__init__.py
+++ b/googleapiclient/discovery_cache/__init__.py
@@ -1,0 +1,42 @@
+# Copyright 2014 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Caching utility for the discovery document."""
+
+from __future__ import absolute_import
+
+import logging
+import datetime
+
+DISCOVERY_DOC_MAX_AGE = 60 * 60 * 24  # 1 day
+
+
+def autodetect():
+  """Detects an appropriate cache module and returns it.
+
+  Returns:
+    googleapiclient.discovery_cache.base.Cache, a cache object which
+    is auto detected, or None if no cache object is available.
+  """
+  try:
+    from google.appengine.api import memcache
+    from . import appengine_memcache
+    return appengine_memcache.cache
+  except Exception:
+    try:
+      from . import file_cache
+      return file_cache.cache
+    except Exception as e:
+      logging.warning(e, exc_info=True)
+      return None

--- a/googleapiclient/discovery_cache/appengine_memcache.py
+++ b/googleapiclient/discovery_cache/appengine_memcache.py
@@ -1,0 +1,52 @@
+# Copyright 2014 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""App Engine memcache based cache for the discovery document."""
+
+import logging
+
+# This is only an optional dependency because we only import this
+# module when google.appengine.api.memcache is available.
+from google.appengine.api import memcache
+
+from . import base
+from ..discovery_cache import DISCOVERY_DOC_MAX_AGE
+
+NAMESPACE = 'google-api-client'
+
+
+class Cache(base.Cache):
+  """A cache with app engine memcache API."""
+
+  def __init__(self, max_age):
+      """Constructor.
+
+      Args:
+        max_age: Cache expiration in seconds.
+      """
+      self._max_age = max_age
+
+  def get(self, url):
+    try:
+      return memcache.get(url, namespace=NAMESPACE)
+    except Exception as e:
+      logging.warning(e, exc_info=True)
+
+  def set(self, url, content):
+    try:
+      memcache.set(url, content, time=int(self._max_age), namespace=NAMESPACE)
+    except Exception as e:
+      logging.warning(e, exc_info=True)
+
+cache = Cache(max_age=DISCOVERY_DOC_MAX_AGE)

--- a/googleapiclient/discovery_cache/base.py
+++ b/googleapiclient/discovery_cache/base.py
@@ -1,0 +1,45 @@
+# Copyright 2014 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""An abstract class for caching the discovery document."""
+
+import abc
+
+
+class Cache(object):
+  """A base abstract cache class."""
+  __metaclass__ = abc.ABCMeta
+
+  @abc.abstractmethod
+  def get(self, url):
+    """Gets the content from the memcache with a given key.
+
+    Args:
+      url: string, the key for the cache.
+
+    Returns:
+      object, the value in the cache for the given key, or None if the key is
+      not in the cache.
+    """
+    raise NotImplementedError()
+
+  @abc.abstractmethod
+  def set(self, url, content):
+    """Sets the given key and content in the cache.
+
+    Args:
+      url: string, the key for the cache.
+      content: string, the discovery document.
+    """
+    raise NotImplementedError()

--- a/googleapiclient/discovery_cache/file_cache.py
+++ b/googleapiclient/discovery_cache/file_cache.py
@@ -1,0 +1,132 @@
+# Copyright 2014 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""File based cache for the discovery document.
+
+The cache is stored in a single file so that multiple processes can
+share the same cache. It locks the file whenever accesing to the
+file. When the cache content is corrupted, it will be initialized with
+an empty cache.
+"""
+
+from __future__ import division
+
+import datetime
+import json
+import logging
+import os
+import tempfile
+import threading
+
+from oauth2client.locked_file import LockedFile
+
+from . import base
+from ..discovery_cache import DISCOVERY_DOC_MAX_AGE
+
+logger = logging.getLogger(__name__)
+
+FILENAME = 'google-api-python-client-discovery-doc.cache'
+EPOCH = datetime.datetime.utcfromtimestamp(0)
+
+
+def _to_timestamp(date):
+  try:
+    return (date - EPOCH).total_seconds()
+  except AttributeError:
+    # The following is the equivalent of total_seconds() in Python2.6.
+    # See also: https://docs.python.org/2/library/datetime.html
+    delta = date - EPOCH
+    return ((delta.microseconds + (delta.seconds + delta.days * 24 * 3600)
+             * 10**6) / 10**6)
+
+
+def _read_or_initialize_cache(f):
+  f.file_handle().seek(0)
+  try:
+    cache = json.load(f.file_handle())
+  except Exception:
+    # This means it opens the file for the first time, or the cache is
+    # corrupted, so initializing the file with an empty dict.
+    cache = {}
+    f.file_handle().truncate(0)
+    f.file_handle().seek(0)
+    json.dump(cache, f.file_handle())
+  return cache
+
+
+class Cache(base.Cache):
+  """A file based cache for the discovery documents."""
+
+  def __init__(self, max_age):
+      """Constructor.
+
+      Args:
+        max_age: Cache expiration in seconds.
+      """
+      self._max_age = max_age
+      self._file = os.path.join(tempfile.gettempdir(), FILENAME)
+      f = LockedFile(self._file, 'a+', 'r')
+      try:
+        f.open_and_lock()
+        if f.is_locked():
+          _read_or_initialize_cache(f)
+        # If we can not obtain the lock, other process or thread must
+        # have initialized the file.
+      except Exception as e:
+        logging.warning(e, exc_info=True)
+      finally:
+        f.unlock_and_close()
+
+  def get(self, url):
+    f = LockedFile(self._file, 'r+', 'r')
+    try:
+      f.open_and_lock()
+      if f.is_locked():
+        cache = _read_or_initialize_cache(f)
+        if url in cache:
+          content, t = cache.get(url, (None, 0))
+          if _to_timestamp(datetime.datetime.now()) < t + self._max_age:
+            return content
+        return None
+      else:
+        logger.debug('Could not obtain a lock for the cache file.')
+        return None
+    except Exception as e:
+      logger.warning(e, exc_info=True)
+    finally:
+      f.unlock_and_close()
+
+  def set(self, url, content):
+    f = LockedFile(self._file, 'r+', 'r')
+    try:
+      f.open_and_lock()
+      if f.is_locked():
+        cache = _read_or_initialize_cache(f)
+        cache[url] = (content, _to_timestamp(datetime.datetime.now()))
+        # Remove stale cache.
+        for k, (_, timestamp) in list(cache.items()):
+          if _to_timestamp(datetime.datetime.now()) >= timestamp + self._max_age:
+            del cache[k]
+        f.file_handle().truncate(0)
+        f.file_handle().seek(0)
+        json.dump(cache, f.file_handle())
+      else:
+        logger.debug('Could not obtain a lock for the cache file.')
+    except Exception as e:
+      logger.warning(e, exc_info=True)
+    finally:
+      f.unlock_and_close()
+
+
+cache = Cache(max_age=DISCOVERY_DOC_MAX_AGE)

--- a/tests/test_discovery_cache.py
+++ b/tests/test_discovery_cache.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2014 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Discovery document cache tests."""
+
+import datetime
+import unittest2 as unittest
+
+import mock
+
+from googleapiclient.discovery_cache import DISCOVERY_DOC_MAX_AGE
+from googleapiclient.discovery_cache.base import Cache
+from googleapiclient.discovery_cache.file_cache import Cache as FileCache
+
+
+class FileCacheTest(unittest.TestCase):
+  @mock.patch('googleapiclient.discovery_cache.file_cache.FILENAME',
+              new='google-api-python-client-discovery-doc-tests.cache')
+  def test_expiration(self):
+    def future_now():
+      return datetime.datetime.now() + datetime.timedelta(
+        seconds=DISCOVERY_DOC_MAX_AGE)
+    mocked_datetime = mock.MagicMock()
+    mocked_datetime.datetime.now.side_effect = future_now
+    cache = FileCache(max_age=DISCOVERY_DOC_MAX_AGE)
+    first_url = 'url-1'
+    first_url_content = 'url-1-content'
+    cache.set(first_url, first_url_content)
+
+    # Make sure the content is cached.
+    self.assertEqual(first_url_content, cache.get(first_url))
+
+    # Simulate another `set` call in the future date.
+    with mock.patch('googleapiclient.discovery_cache.file_cache.datetime',
+                    new=mocked_datetime):
+      cache.set('url-2', 'url-2-content')
+    
+    # Make sure the content is expired
+    self.assertEqual(None, cache.get(first_url))

--- a/tox.ini
+++ b/tox.ini
@@ -11,4 +11,5 @@ deps = keyring
        nose
        coverage>=3.6,<3.99
        unittest2
+       mock
 commands = nosetests --with-coverage --cover-package=googleapiclient --nocapture --cover-erase --cover-tests --cover-branches --cover-min-percentage=85


### PR DESCRIPTION
Added 2 keyword arguments; cache_discovery and cache. You can suppress caching by setting cache_discovery=False. You can inject your own caching module via the cache kwarg.

It automatically uses app engine memcache if it's detected. It's not a hard dependency. Then fall back to file based caching.

fixes #110 