### PR TITLE
Catch exception when path parameters not in message.

### DIFF
--- a/googleapiclient/discovery.py
+++ b/googleapiclient/discovery.py
@@ -57,6 +57,7 @@ from googleapiclient.errors import MediaUploadSizeError
 from googleapiclient.errors import UnacceptableMimeTypeError
 from googleapiclient.errors import UnknownApiNameOrVersion
 from googleapiclient.errors import UnknownFileType
+from googleapiclient.errors import ParameterRequiredError
 from googleapiclient.http import BatchHttpRequest
 from googleapiclient.http import HttpRequest
 from googleapiclient.http import MediaFileUpload
@@ -846,7 +847,10 @@ def createMethod(methodName, methodDesc, rootDesc, schema):
     required = ''
     if arg in parameters.required_params:
       required = ' (required)'
-    paramdesc = methodDesc['parameters'][parameters.argmap[arg]]
+    try:
+      paramdesc = methodDesc['parameters'][parameters.argmap[arg]]
+    except KeyError:
+      raise ParameterRequiredError('Missing path parameter "%s" in input message' % arg)
     paramdoc = paramdesc.get('description', 'A parameter')
     if '$ref' in paramdesc:
       docs.append(

--- a/googleapiclient/errors.py
+++ b/googleapiclient/errors.py
@@ -107,6 +107,10 @@ class InvalidNotificationError(Error):
   """The channel Notification is invalid."""
   pass
 
+class ParameterRequiredError(Error):
+  """The url parameter is not present in the input message."""
+  pass
+
 class BatchError(HttpError):
   """Error occured during batch operations."""
 


### PR DESCRIPTION
Raise an exception when any of the path parameters is not present in the
input message of the endpoint.

Example :

```
@endpoints.method(message_types.VoidMessage, message_types.VoidMessage, path='/{parameter}')
def sample_endpoint(self, request):
    return VoidMessage()