### PR TITLE
Default to octet-stream if mimetype detection fails.

### DIFF
--- a/googleapiclient/http.py
+++ b/googleapiclient/http.py
@@ -425,7 +425,11 @@ class MediaFileUpload(MediaIoBaseUpload):
     self._filename = filename
     fd = open(self._filename, 'rb')
     if mimetype is None:
-      (mimetype, encoding) = mimetypes.guess_type(filename)
+      # No mimetype provided, make a guess.
+      mimetype, _ = mimetypes.guess_type(filename)
+      if mimetype is None:
+        # Guess failed, use octet-stream.
+        mimetype = 'application/octet-stream'
     super(MediaFileUpload, self).__init__(fd, mimetype, chunksize=chunksize,
                                           resumable=resumable)
 

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -131,6 +131,13 @@ class TestUserAgent(unittest.TestCase):
 
 class TestMediaUpload(unittest.TestCase):
 
+  def test_media_file_upload_mimetype_detection(self):
+    upload = MediaFileUpload(datafile('small.png'))
+    self.assertEqual('image/png', upload.mimetype())
+
+    upload = MediaFileUpload(datafile('empty'))
+    self.assertEqual('application/octet-stream', upload.mimetype())
+
   def test_media_file_upload_to_from_json(self):
     upload = MediaFileUpload(
         datafile('small.png'), chunksize=500, resumable=True)


### PR DESCRIPTION
The function mimetypes.guess_type returns (None, None) if it fails to
find a matching extension. In that case, we should just treat the media
as application/octet-stream.