### PR TITLE
Fallback to use new discovery uri pattern when the old one fails.

### DIFF
--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -352,6 +352,7 @@ class DiscoveryErrors(unittest.TestCase):
   def test_unknown_api_name_or_version(self):
       http = HttpMockSequence([
         ({'status': '404'}, open(datafile('zoo.json'), 'rb').read()),
+        ({'status': '404'}, open(datafile('zoo.json'), 'rb').read()),
       ])
       with self.assertRaises(UnknownApiNameOrVersion):
         plus = build('plus', 'v1', http=http, cache_discovery=False)
@@ -424,6 +425,14 @@ class DiscoveryFromHttp(unittest.TestCase):
       self.fail('Should have raised an exception.')
     except HttpError as e:
       self.assertEqual(e.uri, 'http://example.com')
+
+  def test_discovery_loading_from_backup_uri(self):
+    http = HttpMockSequence([
+      ({'status': '404'}, 'Not found'),
+      ({'status': '200'}, open(datafile('zoo.json'), 'rb').read()),
+    ])
+    zoo = build('zoo', 'v1', http=http, cache_discovery=False)
+    self.assertTrue(hasattr(zoo, 'animals'))
 
 
 class DiscoveryFromAppEngineCache(unittest.TestCase):


### PR DESCRIPTION
Fallback to use new discovery uri pattern when the old one fails. Some Google API are now using the new Discovery url style.