### PR TITLE
Import LockedFile from contrib to work with latest oauth2client

### DIFF
--- a/googleapiclient/discovery_cache/file_cache.py
+++ b/googleapiclient/discovery_cache/file_cache.py
@@ -29,7 +29,7 @@ import os
 import tempfile
 import threading
 
-from oauth2client.locked_file import LockedFile
+from oauth2client.contrib.locked_file import LockedFile
 
 from . import base
 from ..discovery_cache import DISCOVERY_DOC_MAX_AGE


### PR DESCRIPTION
It seems the new oauth2client has moved locked file into contrib, and hence my applications throw a warning that it failed to import the module.