### PR TITLE
pep8 + print statement alignment

### DIFF
--- a/samples/calendar_api/calendar_sample.py
+++ b/samples/calendar_api/calendar_sample.py
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#            http://www.apache.org/licenses/LICENSE-2.0
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/calendar_api/calendar_sample.py
+++ b/samples/calendar_api/calendar_sample.py
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#            http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,25 +23,27 @@ import sys
 from oauth2client import client
 from googleapiclient import sample_tools
 
+
 def main(argv):
-  # Authenticate and construct service.
-  service, flags = sample_tools.init(
-      argv, 'calendar', 'v3', __doc__, __file__,
-      scope='https://www.googleapis.com/auth/calendar.readonly')
+    # Authenticate and construct service.
+    service, flags = sample_tools.init(
+        argv, 'calendar', 'v3', __doc__, __file__,
+        scope='https://www.googleapis.com/auth/calendar.readonly')
 
-  try:
-    page_token = None
-    while True:
-      calendar_list = service.calendarList().list(pageToken=page_token).execute()
-      for calendar_list_entry in calendar_list['items']:
-        print calendar_list_entry['summary']
-      page_token = calendar_list.get('nextPageToken')
-      if not page_token:
-        break
+    try:
+        page_token = None
+        while True:
+            calendar_list = service.calendarList().list(
+                pageToken=page_token).execute()
+            for calendar_list_entry in calendar_list['items']:
+                print(calendar_list_entry['summary'])
+            page_token = calendar_list.get('nextPageToken')
+            if not page_token:
+                break
 
-  except client.AccessTokenRefreshError:
-    print ('The credentials have been revoked or expired, please re-run'
-      'the application to re-authorize.')
+    except client.AccessTokenRefreshError:
+        print('The credentials have been revoked or expired, please re-run'
+              'the application to re-authorize.')
 
 if __name__ == '__main__':
-  main(sys.argv)
+    main(sys.argv)


### PR DESCRIPTION
The original:

* Violated pep8
* Used `print()` both as a statement and as a function, guaranteeing that the code won't work in either Python 2.5 or 3.x
* Didn't explain anything about what was happening.

This change fixes two of those problems.