### PR TITLE
Make compatible with oauth2client v2.0.0 (xsrfutil)

### DIFF
--- a/samples/django_sample/plus/views.py
+++ b/samples/django_sample/plus/views.py
@@ -11,7 +11,7 @@ from django.http import HttpResponseRedirect
 from django.shortcuts import render
 from django_sample.plus.models import CredentialsModel
 from django_sample import settings
-from oauth2client import xsrfutil
+from oauth2client.contrib import xsrfutil
 from oauth2client.client import flow_from_clientsecrets
 from oauth2client.contrib.django_orm import Storage
 


### PR DESCRIPTION
The v2.0.0 release moved a xsrfutil module to a subpackage of oauth2client
called contrib