### PR TITLE
Allow using oauth2client versions < 2

### DIFF
--- a/googleapiclient/discovery_cache/file_cache.py
+++ b/googleapiclient/discovery_cache/file_cache.py
@@ -29,7 +29,11 @@ import os
 import tempfile
 import threading
 
-from oauth2client.contrib.locked_file import LockedFile
+try:
+  from oauth2client.contrib.locked_file import LockedFile
+except ImportError:
+  # oauth2client < 2.0.0
+  from oauth2client.locked_file import LockedFile
 
 from . import base
 from ..discovery_cache import DISCOVERY_DOC_MAX_AGE

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ packages = [
 
 install_requires = [
     'httplib2>=0.8,<1',
-    'oauth2client>=2.0.0,<3',
+    'oauth2client',
     'six>=1.6.1,<2',
     'uritemplate>=0.6,<1',
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,11 @@
 [tox]
-envlist = py26, py27, py33, py34
+envlist = py{26,27,33,34}-oauth2client{1,2}
 
 [testenv]
-deps = keyring
+deps =
+       oauth2client1: oauth2client<2
+       oauth2client2: oauth2client>=2,<=3
+       keyring
        mox
        pyopenssl
        pycrypto==2.6


### PR DESCRIPTION
Be compatible with older oauth2client versions. This simplifies
the installation (also for downstream) when software needs an older
oauth2client version but also wants to use googleapiclient.