### PR TITLE
Fallback to use new discovery uri pattern when the old one fails.

### DIFF
--- a/googleapiclient/discovery.py
+++ b/googleapiclient/discovery.py
@@ -82,6 +82,9 @@ URITEMPLATE = re.compile('{[^}]*}')
 VARNAME = re.compile('[a-zA-Z0-9_-]+')
 DISCOVERY_URI = ('https://www.googleapis.com/discovery/v1/apis/'
                  '{api}/{apiVersion}/rest')
+V1_DISCOVERY_URI = DISCOVERY_URI
+V2_DISCOVERY_URI = ('https://{api}.googleapis.com/$discovery/rest?'
+                    'version={apiVersion}')
 DEFAULT_METHOD_DOC = 'A description of how to use this function'
 HTTP_PAYLOAD_METHODS = frozenset(['PUT', 'POST', 'PATCH'])
 _MEDIA_SIZE_BIT_SHIFTS = {'KB': 10, 'MB': 20, 'GB': 30, 'TB': 40}
@@ -196,21 +199,23 @@ def build(serviceName,
   if http is None:
     http = httplib2.Http()
 
-  requested_url = uritemplate.expand(discoveryServiceUrl, params)
+  for discovery_url in (discoveryServiceUrl, V2_DISCOVERY_URI,):
+    requested_url = uritemplate.expand(discovery_url, params)
 
-  try:
-    content = _retrieve_discovery_doc(requested_url, http, cache_discovery,
-                                      cache)
-  except HttpError as e:
-    if e.resp.status == http_client.NOT_FOUND:
-      raise UnknownApiNameOrVersion("name: %s  version: %s" % (serviceName,
-                                                               version))
-    else:
-      raise e
+    try:
+      content = _retrieve_discovery_doc(requested_url, http, cache_discovery,
+                                        cache)
+      return build_from_document(content, base=discovery_url, http=http,
+          developerKey=developerKey, model=model, requestBuilder=requestBuilder,
+          credentials=credentials)
+    except HttpError as e:
+      if e.resp.status == http_client.NOT_FOUND:
+        continue
+      else:
+        raise e
 
-  return build_from_document(content, base=discoveryServiceUrl, http=http,
-      developerKey=developerKey, model=model, requestBuilder=requestBuilder,
-      credentials=credentials)
+  raise UnknownApiNameOrVersion(
+        "name: %s  version: %s" % (serviceName, version))
 
 
 def _retrieve_discovery_doc(url, http, cache_discovery, cache=None):

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -352,6 +352,7 @@ class DiscoveryErrors(unittest.TestCase):
   def test_unknown_api_name_or_version(self):
       http = HttpMockSequence([
         ({'status': '404'}, open(datafile('zoo.json'), 'rb').read()),
+        ({'status': '404'}, open(datafile('zoo.json'), 'rb').read()),
       ])
       with self.assertRaises(UnknownApiNameOrVersion):
         plus = build('plus', 'v1', http=http, cache_discovery=False)
@@ -425,6 +426,13 @@ class DiscoveryFromHttp(unittest.TestCase):
     except HttpError as e:
       self.assertEqual(e.uri, 'http://example.com')
 
+  def test_discovery_loading_from_v2_discovery_uri(self):
+      http = HttpMockSequence([
+        ({'status': '404'}, 'Not found'),
+        ({'status': '200'}, open(datafile('zoo.json'), 'rb').read()),
+      ])
+      zoo = build('zoo', 'v1', http=http, cache_discovery=False)
+      self.assertTrue(hasattr(zoo, 'animals'))
 
 class DiscoveryFromAppEngineCache(unittest.TestCase):
   def test_appengine_memcache(self):


### PR DESCRIPTION
Fallback to use new discovery uri pattern when the old one fails.