### PR TITLE
googleapiclient.http: guard when importing ssl

### DIFF
--- a/googleapiclient/http.py
+++ b/googleapiclient/http.py
@@ -38,10 +38,17 @@ import mimetypes
 import os
 import random
 import socket
-import ssl
 import sys
 import time
 import uuid
+
+# TODO(issue 221): Remove this conditional import jibbajabba.
+try:
+  import ssl
+except ImportError:
+  _ssl_SSLError = object()
+else:
+  _ssl_SSLError = ssl.SSLError
 
 from email.generator import Generator
 from email.mime.multipart import MIMEMultipart
@@ -146,7 +153,7 @@ def _retry_request(http, num_retries, req_type, sleep, rand, uri, method, *args,
       exception = None
       resp, content = http.request(uri, method, *args, **kwargs)
     # Retry on SSL errors and socket timeout errors.
-    except ssl.SSLError as ssl_error:
+    except _ssl_SSLError as ssl_error:
       exception = ssl_error
     except socket.error as socket_error:
       # errno's contents differ by platform, so we have to match by name.


### PR DESCRIPTION
Fix #191 by adding a guard when importing `ssl`, and replace all direct
references to `SSLError` (the sole member of `ssl` being used) with a
shim, `_ssl_SSLError`. It is prefixed with a '_' to caution users
against relying on the name when importing `googleclient.http`.

`httplib2` also takes the same approach (see `ssl_SSLError` in
`httplib2/__init__.py`), but instead of using `None` when faking
`SSLError`, we provide a 'real' class, so that code can continue to
trigger the exception handler for `SSLError` in `googleclient.http` (eg.
in tests, `SSLError`'s are raised). If the shim `_ssl_SSLError` were
`None`, an exception handler for it would not catch anything, as `None`
is not a class and we could never throw anything that could be
"compatible" with `None` [1]

[1] https://docs.python.org/2/reference/compound_stmts.html#except