### PR TITLE
Add a warning when using mocking without cache.

### DIFF
--- a/googleapiclient/discovery.py
+++ b/googleapiclient/discovery.py
@@ -315,6 +315,15 @@ def build_from_document(
 
   if isinstance(service, six.string_types):
     service = json.loads(service)
+
+  if  'rootUrl' not in service and (isinstance(http, (HttpMock,
+                                                      HttpMockSequence))):
+      logger.error("You are using HttpMock or HttpMockSequence without" +
+                   "having the service discovery doc in cache. Try calling " +
+                   "build() without mocking once first to populate the " +
+                   "cache.")
+      raise InvalidJsonError()
+
   base = urljoin(service['rootUrl'], service['servicePath'])
   schema = Schemas(service)
 


### PR DESCRIPTION
See https://github.com/google/google-api-python-client/issues/208 .
If HttpMock or HttpMockSequence is used in a test without the cache
being filled first, a strange KeyError will be thrown. This happens
on e.g. Travis CI. Unfortunately this behavior is used in the tests;
this patch adds a warning for those unfortunate enough to encounter
it.