### PR TITLE
upgrade to unified uritemplate 3.0.0 [closes #57]

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Python 3 in production.
 # Third Party Libraries and Dependencies
 The following libraries will be installed when you install the client library:
 * [httplib2](https://github.com/httplib2/httplib2)
-* [uri-templates](https://github.com/uri-templates/uritemplate-py)
+* [uritemplate](https://github.com/sigmavirus24/uritemplate)
 
 For development you will also need the following libraries:
 * [WebTest](http://pythonpaste.org/webtest/)

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ install_requires = [
     'httplib2>=0.8,<1',
     'oauth2client>=1.5.0,<4.0.0',
     'six>=1.6.1,<2',
-    'uritemplate>=0.6,<1',
+    'uritemplate>=3.0.0,<4',
 ]
 
 if sys.version_info < (2, 7):


### PR DESCRIPTION
As of uritemplate 3.0.0 and uritemplate.py 3.0.2, the two packages are equivalent.
There were no changes to functionality; see
https://github.com/sigmavirus24/uritemplate/blob/master/HISTORY.rst.

This resolves the conflict described in https://github.com/google/google-api-python-client/issues/57.