### PR TITLE
Fix error in resumable upload handler

### DIFF
--- a/googleapiclient/http.py
+++ b/googleapiclient/http.py
@@ -996,7 +996,11 @@ class HttpRequest(object):
     elif resp.status == 308:
       self._in_error_state = False
       # A "308 Resume Incomplete" indicates we are not done.
-      self.resumable_progress = int(resp['range'].split('-')[1]) + 1
+      try:
+        self.resumable_progress = int(resp['range'].split('-')[1]) + 1
+      except KeyError:
+        # If resp doesn't contain range header, resumable progress is 0
+        self.resumable_progress = 0
       if 'location' in resp:
         self.resumable_uri = resp['location']
     else:

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -868,13 +868,13 @@ class Discovery(unittest.TestCase):
       ({'status': '200',
         'location': 'http://upload.example.com'}, ''),
       ({'status': '308',
-        'location': 'http://upload.example.com/2',
-        'range': '0-12'}, ''),
+        'location': 'http://upload.example.com/2', ''}),
       ({'status': '308',
         'location': 'http://upload.example.com/3',
-        'range': '0-%d' % (media_upload.size() - 2)}, ''),
+        'range': '0-12'}, ''),
       ({'status': '308',
-        'location': 'http://upload.example.com/4'}, ''),
+        'location': 'http://upload.example.com/4',
+        'range': '0-%d' % (media_upload.size() - 2)}, ''),
       ({'status': '200'}, '{"foo": "bar"}'),
       ])
 
@@ -886,12 +886,17 @@ class Discovery(unittest.TestCase):
     # Two requests should have been made and the resumable_uri should have been
     # updated for each one.
     self.assertEquals(request.resumable_uri, 'http://upload.example.com/2')
-
+    self.assertEquals(media_upload, request.resumable)
+    self.assertEquals(1, request.resumable_progress)
+    
+    # This next chuck call should ask for the first chuck size
+    status, body = request.next_chunk(http=http)
+    self.assertEquals(request.resumable_uri, 'http://upload.example.com/3')
     self.assertEquals(media_upload, request.resumable)
     self.assertEquals(13, request.resumable_progress)
 
     status, body = request.next_chunk(http=http)
-    self.assertEquals(request.resumable_uri, 'http://upload.example.com/3')
+    self.assertEquals(request.resumable_uri, 'http://upload.example.com/4')
     self.assertEquals(media_upload.size()-1, request.resumable_progress)
     self.assertEquals('{"data": {}}', request.body)
 

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -881,7 +881,7 @@ class Discovery(unittest.TestCase):
     status, body = request.next_chunk(http=http)
     self.assertEquals(None, body)
     self.assertTrue(isinstance(status, MediaUploadProgress))
-    self.assertEquals(13, status.resumable_progress)
+    self.assertEquals(0, status.resumable_progress)
 
     # Two requests should have been made and the resumable_uri should have been
     # updated for each one.
@@ -889,12 +889,13 @@ class Discovery(unittest.TestCase):
     self.assertEquals(media_upload, request.resumable)
     self.assertEquals(0, request.resumable_progress)
     
-    # This next chuck call should ask for the first chuck size
+    # This next chuck call should upload the first chunk
     status, body = request.next_chunk(http=http)
     self.assertEquals(request.resumable_uri, 'http://upload.example.com/3')
     self.assertEquals(media_upload, request.resumable)
     self.assertEquals(13, request.resumable_progress)
 
+    # This call will upload the next chunk
     status, body = request.next_chunk(http=http)
     self.assertEquals(request.resumable_uri, 'http://upload.example.com/4')
     self.assertEquals(media_upload.size()-1, request.resumable_progress)

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -873,6 +873,8 @@ class Discovery(unittest.TestCase):
       ({'status': '308',
         'location': 'http://upload.example.com/3',
         'range': '0-%d' % (media_upload.size() - 2)}, ''),
+      ({'status': '308',
+        'location': 'http://upload.example.com/4'}, ''),
       ({'status': '200'}, '{"foo": "bar"}'),
       ])
 

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -887,7 +887,7 @@ class Discovery(unittest.TestCase):
     # updated for each one.
     self.assertEquals(request.resumable_uri, 'http://upload.example.com/2')
     self.assertEquals(media_upload, request.resumable)
-    self.assertEquals(1, request.resumable_progress)
+    self.assertEquals(0, request.resumable_progress)
     
     # This next chuck call should ask for the first chuck size
     status, body = request.next_chunk(http=http)

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -868,7 +868,7 @@ class Discovery(unittest.TestCase):
       ({'status': '200',
         'location': 'http://upload.example.com'}, ''),
       ({'status': '308',
-        'location': 'http://upload.example.com/2', ''}),
+        'location': 'http://upload.example.com/2'}, ''),
       ({'status': '308',
         'location': 'http://upload.example.com/3',
         'range': '0-12'}, ''),


### PR DESCRIPTION
The client library depends on the range header being in the response when the HTTP response code is 308, but the range header is not present in the response when the server hasn't received any bytes previously. This PR defaults to 0 in that case.
