### PR TITLE
Add support for google-auth

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ sudo: false
 cache: pip
 env:
   matrix:
-  - TOX_ENV=py26
   - TOX_ENV=py27
   - TOX_ENV=py33
   - TOX_ENV=py34

--- a/googleapiclient/_auth.py
+++ b/googleapiclient/_auth.py
@@ -41,7 +41,7 @@ def default_credentials():
     else:
         raise EnvironmentError(
             'No authentication library is available. Please install either '
-            'oauth2client or google-auth.')
+            'google-auth or oauth2client.')
 
 
 def with_scopes(credentials, scopes):

--- a/googleapiclient/_auth.py
+++ b/googleapiclient/_auth.py
@@ -1,0 +1,90 @@
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helpers for authentication using oauth2client or google-auth."""
+
+import httplib2
+
+try:
+    import google.auth
+    import google_auth_httplib2
+    HAS_GOOGLE_AUTH = True
+except ImportError:  # pragma: NO COVER
+    HAS_GOOGLE_AUTH = False
+
+try:
+    import oauth2client
+    import oauth2client.client
+    HAS_OAUTH2CLIENT = True
+except ImportError:  # pragma: NO COVER
+    HAS_OAUTH2CLIENT = False
+
+
+def default_credentials():
+    """Returns Application Default Credentials."""
+    if HAS_GOOGLE_AUTH:
+        credentials, _ = google.auth.default()
+        return credentials
+    elif HAS_OAUTH2CLIENT:
+        return oauth2client.client.GoogleCredentials.get_application_default()
+    else:
+        raise EnvironmentError(
+            'No authentication library is available. Please install either '
+            'oauth2client or google-auth.')
+
+
+def with_scopes(credentials, scopes):
+    """Scopes the credentials if necessary.
+
+    Args:
+        credentials (Union[
+            google.auth.credentials.Credentials,
+            oauth2client.client.Credentials]): The credentials to scope.
+        scopes (Sequence[str]): The list of scopes.
+
+    Returns:
+        Union[google.auth.credentials.Credentials,
+            oauth2client.client.Credentials]: The scoped credentials.
+    """
+    if HAS_GOOGLE_AUTH and isinstance(
+            credentials, google.auth.credentials.Credentials):
+        return google.auth.credentials.with_scopes_if_required(
+            credentials, scopes)
+    else:
+        try:
+            if credentials.create_scoped_required():
+                return credentials.create_scoped(scopes)
+            else:
+                return credentials
+        except AttributeError:
+            return credentials
+
+
+def authorized_http(credentials):
+    """Returns an http client that is authorized with the given credentials.
+
+    Args:
+        credentials (Union[
+            google.auth.credentials.Credentials,
+            oauth2client.client.Credentials]): The credentials to use.
+
+    Returns:
+        Union[httplib2.Http, google_auth_httplib2.AuthorizedHttp]: An
+            authorized http client.
+    """
+    if HAS_GOOGLE_AUTH and isinstance(
+            credentials, google.auth.credentials.Credentials):
+        return google_auth_httplib2.AuthorizedHttp(credentials)
+    else:
+        return credentials.authorize(httplib2.Http())

--- a/googleapiclient/discovery.py
+++ b/googleapiclient/discovery.py
@@ -198,7 +198,8 @@ def build(serviceName,
     model: googleapiclient.Model, converts to and from the wire format.
     requestBuilder: googleapiclient.http.HttpRequest, encapsulator for an HTTP
       request.
-    credentials: oauth2client.Credentials, credentials to be used for
+    credentials: oauth2client.Credentials or
+      google.auth.credentials.Credentials, credentials to be used for
       authentication.
     cache_discovery: Boolean, whether or not to cache the discovery doc.
     cache: googleapiclient.discovery_cache.base.CacheBase, an optional
@@ -316,7 +317,9 @@ def build_from_document(
     model: Model class instance that serializes and de-serializes requests and
       responses.
     requestBuilder: Takes an http request and packages it up to be executed.
-    credentials: object, credentials to be used for authentication.
+    credentials: oauth2client.Credentials or
+      google.auth.credentials.Credentials, credentials to be used for
+      authentication.
 
   Returns:
     A Resource object with methods for interacting with the service.

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,8 @@ from __future__ import print_function
 
 import sys
 
-if sys.version_info < (2, 6):
-  print('google-api-python-client requires python version >= 2.6.',
+if sys.version_info < (2, 7):
+  print('google-api-python-client requires python version >= 2.7.',
         file=sys.stderr)
   sys.exit(1)
 if (3, 1) <= sys.version_info < (3, 3):
@@ -69,9 +69,6 @@ install_requires = [
     'uritemplate>=3.0.0,<4dev',
 ]
 
-if sys.version_info < (2, 7):
-  install_requires.append('argparse')
-
 long_desc = """The Google API Client for Python is a client library for
 accessing the Plus, Moderator, and many other Google APIs."""
 
@@ -92,7 +89,6 @@ setup(
     keywords="google api client",
     classifiers=[
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',

--- a/tests/test__auth.py
+++ b/tests/test__auth.py
@@ -1,0 +1,134 @@
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import mock
+
+import google.auth.credentials
+import google_auth_httplib2
+import httplib2
+import oauth2client.client
+import unittest2
+
+from googleapiclient import _auth
+
+
+class TestAuthWithGoogleAuth(unittest2.TestCase):
+    def setUp(self):
+        _auth.HAS_GOOGLE_AUTH = True
+        _auth.HAS_OAUTH2CLIENT = False
+
+    def tearDown(self):
+        _auth.HAS_GOOGLE_AUTH = True
+        _auth.HAS_OAUTH2CLIENT = True
+
+    def test_default_credentials(self):
+        with mock.patch('google.auth.default', autospec=True) as default:
+            default.return_value = (
+                mock.sentinel.credentials, mock.sentinel.project)
+
+            credentials = _auth.default_credentials()
+
+            self.assertEqual(credentials, mock.sentinel.credentials)
+
+    def test_with_scopes_non_scoped(self):
+        credentials = mock.Mock(spec=google.auth.credentials.Credentials)
+
+        returned = _auth.with_scopes(credentials, mock.sentinel.scopes)
+
+        self.assertEqual(credentials, returned)
+
+    def test_with_scopes_scoped(self):
+        class CredentialsWithScopes(
+                google.auth.credentials.Credentials,
+                google.auth.credentials.Scoped):
+            pass
+
+        credentials = mock.Mock(spec=CredentialsWithScopes)
+        credentials.requires_scopes = True
+
+        returned = _auth.with_scopes(credentials, mock.sentinel.scopes)
+
+        self.assertNotEqual(credentials, returned)
+        self.assertEqual(returned, credentials.with_scopes.return_value)
+        credentials.with_scopes.assert_called_once_with(mock.sentinel.scopes)
+
+    def test_authorized_http(self):
+        credentials = mock.Mock(spec=google.auth.credentials.Credentials)
+
+        http = _auth.authorized_http(credentials)
+
+        self.assertIsInstance(http, google_auth_httplib2.AuthorizedHttp)
+        self.assertEqual(http.credentials, credentials)
+
+
+class TestAuthWithOAuth2Client(unittest2.TestCase):
+    def setUp(self):
+        _auth.HAS_GOOGLE_AUTH = False
+        _auth.HAS_OAUTH2CLIENT = True
+
+    def tearDown(self):
+        _auth.HAS_GOOGLE_AUTH = True
+        _auth.HAS_OAUTH2CLIENT = True
+
+    def test_default_credentials(self):
+        default_patch = mock.patch(
+            'oauth2client.client.GoogleCredentials.get_application_default')
+
+        with default_patch as default:
+            default.return_value = mock.sentinel.credentials
+
+            credentials = _auth.default_credentials()
+
+            self.assertEqual(credentials, mock.sentinel.credentials)
+
+    def test_with_scopes_non_scoped(self):
+        credentials = mock.Mock(spec=oauth2client.client.Credentials)
+
+        returned = _auth.with_scopes(credentials, mock.sentinel.scopes)
+
+        self.assertEqual(credentials, returned)
+
+    def test_with_scopes_scoped(self):
+        credentials = mock.Mock(spec=oauth2client.client.GoogleCredentials)
+        credentials.create_scoped_required.return_value = True
+
+        returned = _auth.with_scopes(credentials, mock.sentinel.scopes)
+
+        self.assertNotEqual(credentials, returned)
+        self.assertEqual(returned, credentials.create_scoped.return_value)
+        credentials.create_scoped.assert_called_once_with(mock.sentinel.scopes)
+
+    def test_authorized_http(self):
+        credentials = mock.Mock(spec=oauth2client.client.Credentials)
+
+        http = _auth.authorized_http(credentials)
+
+        self.assertEqual(http, credentials.authorize.return_value)
+        self.assertIsInstance(
+            credentials.authorize.call_args[0][0], httplib2.Http)
+
+
+class TestAuthWithoutAuth(unittest2.TestCase):
+
+    def setUp(self):
+        _auth.HAS_GOOGLE_AUTH = False
+        _auth.HAS_OAUTH2CLIENT = False
+
+    def tearDown(self):
+        _auth.HAS_GOOGLE_AUTH = True
+        _auth.HAS_OAUTH2CLIENT = True
+
+    def test_default_credentials(self):
+        with self.assertRaises(EnvironmentError):
+            print(_auth.default_credentials())

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -375,17 +375,22 @@ class DiscoveryErrors(unittest.TestCase):
 
 
 class DiscoveryFromDocument(unittest.TestCase):
+  MOCK_CREDENTIALS = mock.Mock(spec=google.auth.credentials.Credentials)
 
   def test_can_build_from_local_document(self):
     discovery = open(datafile('plus.json')).read()
-    plus = build_from_document(discovery, base="https://www.googleapis.com/")
+    plus = build_from_document(
+      discovery, base="https://www.googleapis.com/",
+      credentials=self.MOCK_CREDENTIALS)
     self.assertTrue(plus is not None)
     self.assertTrue(hasattr(plus, 'activities'))
 
   def test_can_build_from_local_deserialized_document(self):
     discovery = open(datafile('plus.json')).read()
     discovery = json.loads(discovery)
-    plus = build_from_document(discovery, base="https://www.googleapis.com/")
+    plus = build_from_document(
+      discovery, base="https://www.googleapis.com/",
+      credentials=self.MOCK_CREDENTIALS)
     self.assertTrue(plus is not None)
     self.assertTrue(hasattr(plus, 'activities'))
 
@@ -393,12 +398,15 @@ class DiscoveryFromDocument(unittest.TestCase):
     discovery = open(datafile('plus.json')).read()
 
     base = "https://www.example.com/"
-    plus = build_from_document(discovery, base=base)
+    plus = build_from_document(
+      discovery, base=base, credentials=self.MOCK_CREDENTIALS)
     self.assertEquals("https://www.googleapis.com/plus/v1/", plus._baseUrl)
 
   def test_building_with_optional_http(self):
     discovery = open(datafile('plus.json')).read()
-    plus = build_from_document(discovery, base="https://www.googleapis.com/")
+    plus = build_from_document(
+      discovery, base="https://www.googleapis.com/",
+      credentials=self.MOCK_CREDENTIALS)
     self.assertIsInstance(
       plus._http, (httplib2.Http, google_auth_httplib2.AuthorizedHttp))
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,8 @@ deps =
        oauth2client2: oauth2client>=2,<=3dev
        oauth2client3: oauth2client>=3,<=4dev
        oauth2client4: oauth2client>=4,<=5dev
+       google-auth
+       google-auth-httplib2
        keyring
        mox
        pyopenssl

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{26,27,33,34}-oauth2client{1,2,3,4}
+envlist = py{27,33,34}-oauth2client{1,2,3,4}
 
 [testenv]
 deps =


### PR DESCRIPTION
This also obviates the need to pass credentials into `discovery.build` or `discovery.build_from_document` if you're using ADC. This library can now automatically acquire those.