### PR TITLE
Set default timeout for all the HTTP requests

### DIFF
--- a/describe.py
+++ b/describe.py
@@ -34,7 +34,7 @@ from googleapiclient.discovery import DISCOVERY_URI
 from googleapiclient.discovery import build
 from googleapiclient.discovery import build_from_document
 from googleapiclient.discovery import UnknownApiNameOrVersion
-import httplib2
+from googleapiclient.http import build_http
 import uritemplate
 
 CSS = """<style>
@@ -346,6 +346,7 @@ def document_api(name, version):
     print 'Warning: {} {} found but could not be built.'.format(name, version)
     return
 
+  http = build_http()
   response, content = http.request(
       uritemplate.expand(
           FLAGS.discovery_uri_template, {
@@ -366,7 +367,7 @@ def document_api_from_discovery_document(uri):
   Args:
     uri: string, URI of discovery document.
   """
-  http = httplib2.Http()
+  http = build_http()
   response, content = http.request(FLAGS.discovery_uri)
   discovery = json.loads(content)
 
@@ -384,7 +385,7 @@ if __name__ == '__main__':
   if FLAGS.discovery_uri:
     document_api_from_discovery_document(FLAGS.discovery_uri)
   else:
-    http = httplib2.Http()
+    http = build_http()
     resp, content = http.request(
         FLAGS.directory_uri,
         headers={'X-User-IP': '0.0.0.0'})

--- a/googleapiclient/_auth.py
+++ b/googleapiclient/_auth.py
@@ -14,8 +14,6 @@
 
 """Helpers for authentication using oauth2client or google-auth."""
 
-import httplib2
-
 try:
     import google.auth
     import google_auth_httplib2
@@ -29,6 +27,8 @@ try:
     HAS_OAUTH2CLIENT = True
 except ImportError:  # pragma: NO COVER
     HAS_OAUTH2CLIENT = False
+
+from googleapiclient.http import build_http
 
 
 def default_credentials():
@@ -85,6 +85,7 @@ def authorized_http(credentials):
     """
     if HAS_GOOGLE_AUTH and isinstance(
             credentials, google.auth.credentials.Credentials):
-        return google_auth_httplib2.AuthorizedHttp(credentials)
+        return google_auth_httplib2.AuthorizedHttp(credentials,
+                                                   http=build_http())
     else:
-        return credentials.authorize(httplib2.Http())
+        return credentials.authorize(build_http())

--- a/googleapiclient/discovery.py
+++ b/googleapiclient/discovery.py
@@ -98,7 +98,7 @@ V2_DISCOVERY_URI = ('https://{api}.googleapis.com/$discovery/rest?'
                     'version={apiVersion}')
 DEFAULT_METHOD_DOC = 'A description of how to use this function'
 HTTP_PAYLOAD_METHODS = frozenset(['PUT', 'POST', 'PATCH'])
-DEFAULT_HTTP_TIMEOUT_SEC = 300 # 5 minutes
+DEFAULT_HTTP_TIMEOUT_SEC = 60
 _MEDIA_SIZE_BIT_SHIFTS = {'KB': 10, 'MB': 20, 'GB': 30, 'TB': 40}
 BODY_PARAMETER_DEFAULT_VALUE = {
     'description': 'The request body.',

--- a/googleapiclient/discovery.py
+++ b/googleapiclient/discovery.py
@@ -47,7 +47,6 @@ import logging
 import mimetypes
 import os
 import re
-import socket
 
 # Third-party imports
 import httplib2
@@ -62,6 +61,7 @@ from googleapiclient.errors import MediaUploadSizeError
 from googleapiclient.errors import UnacceptableMimeTypeError
 from googleapiclient.errors import UnknownApiNameOrVersion
 from googleapiclient.errors import UnknownFileType
+from googleapiclient.http import build_http
 from googleapiclient.http import BatchHttpRequest
 from googleapiclient.http import HttpMock
 from googleapiclient.http import HttpMockSequence
@@ -98,7 +98,7 @@ V2_DISCOVERY_URI = ('https://{api}.googleapis.com/$discovery/rest?'
                     'version={apiVersion}')
 DEFAULT_METHOD_DOC = 'A description of how to use this function'
 HTTP_PAYLOAD_METHODS = frozenset(['PUT', 'POST', 'PATCH'])
-DEFAULT_HTTP_TIMEOUT_SEC = 60
+
 _MEDIA_SIZE_BIT_SHIFTS = {'KB': 10, 'MB': 20, 'GB': 30, 'TB': 40}
 BODY_PARAMETER_DEFAULT_VALUE = {
     'description': 'The request body.',
@@ -216,8 +216,7 @@ def build(serviceName,
       }
 
   if http is None:
-    http_timeout = socket.getdefaulttimeout() if socket.getdefaulttimeout() else DEFAULT_HTTP_TIMEOUT_SEC
-    discovery_http = httplib2.Http(timeout=http_timeout)
+    discovery_http = build_http()
   else:
     discovery_http = http
 
@@ -372,7 +371,7 @@ def build_from_document(
     # If the service doesn't require scopes then there is no need for
     # authentication.
     else:
-      http = httplib2.Http()
+      http = build_http()
 
   if model is None:
     features = service.get('features', [])

--- a/googleapiclient/discovery.py
+++ b/googleapiclient/discovery.py
@@ -98,7 +98,7 @@ V2_DISCOVERY_URI = ('https://{api}.googleapis.com/$discovery/rest?'
                     'version={apiVersion}')
 DEFAULT_METHOD_DOC = 'A description of how to use this function'
 HTTP_PAYLOAD_METHODS = frozenset(['PUT', 'POST', 'PATCH'])
-HTTP_TIMEOUT_SEC = 300 # 5 minutes
+DEFAULT_HTTP_TIMEOUT_SEC = 300 # 5 minutes
 _MEDIA_SIZE_BIT_SHIFTS = {'KB': 10, 'MB': 20, 'GB': 30, 'TB': 40}
 BODY_PARAMETER_DEFAULT_VALUE = {
     'description': 'The request body.',
@@ -216,7 +216,7 @@ def build(serviceName,
       }
 
   if http is None:
-    http_timeout = socket.getdefaulttimeout() if socket.getdefaulttimeout() else HTTP_TIMEOUT_SEC
+    http_timeout = socket.getdefaulttimeout() if socket.getdefaulttimeout() else DEFAULT_HTTP_TIMEOUT_SEC
     discovery_http = httplib2.Http(timeout=http_timeout)
   else:
     discovery_http = http

--- a/googleapiclient/discovery.py
+++ b/googleapiclient/discovery.py
@@ -47,6 +47,7 @@ import logging
 import mimetypes
 import os
 import re
+import socket
 
 # Third-party imports
 import httplib2
@@ -97,6 +98,7 @@ V2_DISCOVERY_URI = ('https://{api}.googleapis.com/$discovery/rest?'
                     'version={apiVersion}')
 DEFAULT_METHOD_DOC = 'A description of how to use this function'
 HTTP_PAYLOAD_METHODS = frozenset(['PUT', 'POST', 'PATCH'])
+HTTP_TIMEOUT_SEC = 300 # 5 minutes
 _MEDIA_SIZE_BIT_SHIFTS = {'KB': 10, 'MB': 20, 'GB': 30, 'TB': 40}
 BODY_PARAMETER_DEFAULT_VALUE = {
     'description': 'The request body.',
@@ -213,7 +215,11 @@ def build(serviceName,
       'apiVersion': version
       }
 
-  discovery_http = http if http is not None else httplib2.Http()
+  if http is None:
+    http_timeout = socket.getdefaulttimeout() if socket.getdefaulttimeout() else HTTP_TIMEOUT_SEC
+    discovery_http = httplib2.Http(timeout=http_timeout)
+  else:
+    discovery_http = http
 
   for discovery_url in (discoveryServiceUrl, V2_DISCOVERY_URI,):
     requested_url = uritemplate.expand(discovery_url, params)

--- a/googleapiclient/http.py
+++ b/googleapiclient/http.py
@@ -80,6 +80,8 @@ MAX_URI_LENGTH = 2048
 
 _TOO_MANY_REQUESTS = 429
 
+DEFAULT_HTTP_TIMEOUT_SEC = 60
+
 
 def _should_retry_response(resp_status, content):
   """Determines whether a response should be retried.
@@ -1732,3 +1734,21 @@ def tunnel_patch(http):
 
   http.request = new_request
   return http
+
+
+def build_http():
+  """Builds httplib2.Http object
+
+  Returns:
+  A httplib2.Http object, which is used to make http requests, and which has timeout set by default.
+  To override default timeout call
+
+    socket.setdefaulttimeout(timeout_in_sec)
+
+  before interacting with this method.
+  """
+  if socket.getdefaulttimeout() is not None:
+    http_timeout = socket.getdefaulttimeout()
+  else:
+    http_timeout = DEFAULT_HTTP_TIMEOUT_SEC
+  return httplib2.Http(timeout=http_timeout)

--- a/googleapiclient/sample_tools.py
+++ b/googleapiclient/sample_tools.py
@@ -23,10 +23,10 @@ __all__ = ['init']
 
 
 import argparse
-import httplib2
 import os
 
 from googleapiclient import discovery
+from googleapiclient.http import build_http
 from oauth2client import client
 from oauth2client import file
 from oauth2client import tools
@@ -88,7 +88,7 @@ def init(argv, name, version, doc, filename, scope=None, parents=[], discovery_f
   credentials = storage.get()
   if credentials is None or credentials.invalid:
     credentials = tools.run_flow(flow, storage, flags)
-  http = credentials.authorize(http = httplib2.Http())
+  http = credentials.authorize(http=build_http())
 
   if discovery_filename is None:
     # Construct a service object via the discovery service.

--- a/tests/test__auth.py
+++ b/tests/test__auth.py
@@ -66,10 +66,13 @@ class TestAuthWithGoogleAuth(unittest2.TestCase):
     def test_authorized_http(self):
         credentials = mock.Mock(spec=google.auth.credentials.Credentials)
 
-        http = _auth.authorized_http(credentials)
+        authorized_http = _auth.authorized_http(credentials)
 
-        self.assertIsInstance(http, google_auth_httplib2.AuthorizedHttp)
-        self.assertEqual(http.credentials, credentials)
+        self.assertIsInstance(authorized_http, google_auth_httplib2.AuthorizedHttp)
+        self.assertEqual(authorized_http.credentials, credentials)
+        self.assertIsInstance(authorized_http.http, httplib2.Http)
+        self.assertIsInstance(authorized_http.http.timeout, int)
+        self.assertGreater(authorized_http.http.timeout, 0)
 
 
 class TestAuthWithOAuth2Client(unittest2.TestCase):
@@ -112,11 +115,14 @@ class TestAuthWithOAuth2Client(unittest2.TestCase):
     def test_authorized_http(self):
         credentials = mock.Mock(spec=oauth2client.client.Credentials)
 
-        http = _auth.authorized_http(credentials)
+        authorized_http = _auth.authorized_http(credentials)
 
-        self.assertEqual(http, credentials.authorize.return_value)
-        self.assertIsInstance(
-            credentials.authorize.call_args[0][0], httplib2.Http)
+        http = credentials.authorize.call_args[0][0]
+
+        self.assertEqual(authorized_http, credentials.authorize.return_value)
+        self.assertIsInstance(http, httplib2.Http)
+        self.assertIsInstance(http.timeout, int)
+        self.assertGreater(http.timeout, 0)
 
 
 class TestAuthWithoutAuth(unittest2.TestCase):


### PR DESCRIPTION
This will avoid having hanging connections when using Google API calls.

In case the user have set default socket timeout, that value is used instead of default.