### PR TITLE
Allow setting user-agent header for api methods.

### DIFF
--- a/googleapiclient/discovery.py
+++ b/googleapiclient/discovery.py
@@ -708,7 +708,7 @@ def createMethod(methodName, methodDesc, rootDesc, schema):
 
   parameters = ResourceMethodParameters(methodDesc)
 
-  def method(self, **kwargs):
+  def method(self, user_agent=None, **kwargs):
     # Don't bother with doc string, it will be over-written by createMethod.
 
     for name in six.iterkeys(kwargs):
@@ -780,6 +780,8 @@ def createMethod(methodName, methodDesc, rootDesc, schema):
       model = RawModel()
 
     headers = {}
+    if user_agent is not None:
+      headers['user-agent'] = user_agent
     headers, params, query, body = model.request(headers,
         actual_path_params, actual_query_params, body_value)
 

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -302,6 +302,14 @@ class Utilities(unittest.TestCase):
       self.assertEqual(final_url, _urljoin(base, url))
 
 
+  def test_user_agent_headers(self):
+    self.http = HttpMock(datafile('zoo.json'), {'status': '200'})
+    zoo = build('zoo', 'v1', http=self.http)
+
+    request = zoo.animals().insert(body={}, user_agent='zookeeper')
+    self.assertTrue(request.headers['user-agent'].startswith('zookeeper'))
+
+
   def test_ResourceMethodParameters_zoo_get(self):
     parameters = ResourceMethodParameters(self.zoo_get_method_desc)
 
@@ -934,7 +942,6 @@ class Discovery(unittest.TestCase):
     self.assertEquals(request.resumable_uri, 'http://upload.example.com/2')
     self.assertEquals(media_upload, request.resumable)
     self.assertEquals(0, request.resumable_progress)
-    
     # This next chuck call should upload the first chunk
     status, body = request.next_chunk(http=http)
     self.assertEquals(request.resumable_uri, 'http://upload.example.com/3')


### PR DESCRIPTION
Allow setting user-agent header for api methods.

Now if one need to call an API method with his own user agent, he may
just use user_agent keyword argument for method call.

Resolves: #342