### PR TITLE
App default creds

### DIFF
--- a/googleapiclient/http.py
+++ b/googleapiclient/http.py
@@ -1202,7 +1202,17 @@ class BatchHttpRequest(object):
 
     if request.http is not None and hasattr(request.http.request,
         'credentials'):
-      request.http.request.credentials.apply(headers)
+      credentials = request.http.request.credentials
+      if (hasattr(credentials, 'access_token') and
+          credentials.access_token is None):
+        # It is possible to have credentials and still not have an access token.
+        # (e.g. with application default credentials on GAE).  If that is the
+        # case, do not serialize the authentication headers with this request.
+        # Instead, assume that the batch has an authorization header which will
+        # trickle down to all of the individual requests.
+        pass
+      else:
+        credentials.apply(headers)
 
     # MIMENonMultipart adds its own Content-Type header.
     if 'content-type' in headers:

--- a/googleapiclient/http.py
+++ b/googleapiclient/http.py
@@ -88,7 +88,7 @@ def _should_retry_response(resp_status, content):
 
   Args:
     resp_status: The response status received.
-    content: The response content body. 
+    content: The response content body.
 
   Returns:
     True if the response should be retried, otherwise False.

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -123,7 +123,7 @@ class HttpMockWithErrors(object):
           ex = TimeoutError()
         else:
           ex = socket.error()
-        
+
         if self.num_errors == 2:
           #first try a broken pipe error (#218)
           ex.errno = socket.errno.EPIPE
@@ -929,6 +929,7 @@ class TestHttpRequest(unittest.TestCase):
       request.execute()
     request._sleep.assert_not_called()
 
+
 class TestBatch(unittest.TestCase):
 
   def setUp(self):
@@ -1130,6 +1131,41 @@ class TestBatch(unittest.TestCase):
     self.assertEqual(1, cred._authorized)
 
     self.assertEqual(1, cred._applied)
+
+  def test_execute_request_http_not_applied_if_no_access_token(self):
+    batch = BatchHttpRequest()
+    cred_1 = MockCredentials('Foo')
+    cred_2 = MockCredentials('Bar')
+
+    # Pretend that the credentials are OAuth2Credentials instances.
+    cred_1.access_token = None  # AssertionCredentials instance.
+    cred_2.access_token = 'NotNone'  # vanilla OAuth2Credentials instance.
+
+    http = HttpMockSequence([
+      ({'status': '200',
+        'content-type': 'multipart/mixed; boundary="batch_foobarbaz"'},
+       BATCH_RESPONSE_WITH_401),
+      ({'status': '200',
+        'content-type': 'multipart/mixed; boundary="batch_foobarbaz"'},
+       BATCH_SINGLE_RESPONSE),
+      ])
+
+    creds_http_1 = HttpMockSequence([])
+    creds_http_2 = HttpMockSequence([])
+
+    cred_1.authorize(creds_http_1)
+    cred_2.authorize(creds_http_2)
+
+    self.request1.http = creds_http_1
+    self.request2.http = creds_http_2
+
+    batch.add(self.request1)
+    batch.add(self.request2)
+
+    batch.execute(http=http)
+
+    self.assertEqual(cred_1._applied, 0)
+    self.assertEqual(cred_2._applied, 1)
 
   def test_execute_refresh_and_retry_on_401(self):
     batch = BatchHttpRequest()


### PR DESCRIPTION
Only authenticate individual requests in a batch if the credentials are non-`None`.  Otherwise, assume that an appropriate authentication is being provided at a higher level (e.g. for the entire batch)

This should address #350 