### PR TITLE
Python 3.3 is no longer supported

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,8 @@ if sys.version_info < (2, 7):
   print('google-api-python-client requires python version >= 2.7.',
         file=sys.stderr)
   sys.exit(1)
-if (3, 1) <= sys.version_info < (3, 3):
-  print('google-api-python-client requires python3 version >= 3.3.',
+if (3, 1) <= sys.version_info < (3, 4):
+  print('google-api-python-client requires python3 version >= 3.4.',
         file=sys.stderr)
   sys.exit(1)
 
@@ -91,7 +91,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',


### PR DESCRIPTION
For example, see its removal in https://github.com/google/google-api-python-client/pull/341.

TODO:

* [ ] These [docs](https://developers.google.com/api-client-library/python/apis/customsearch/v1) also need updating: "Python 2.6, 2.7, 3.3, or 3.4". Are they open source too?
