### PR TITLE
Raise ValueError if credentials and developerKey are both specified

### DIFF
--- a/googleapiclient/discovery.py
+++ b/googleapiclient/discovery.py
@@ -334,6 +334,10 @@ def build_from_document(
   if http is not None and credentials is not None:
     raise ValueError('Arguments http and credentials are mutually exclusive.')
 
+  if developerKey is not None and credentials is not None:
+    raise ValueError(
+      'Arguments developerKey and credentials are mutually exclusive.')
+
   if isinstance(service, six.string_types):
     service = json.loads(service)
 

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -375,6 +375,13 @@ class DiscoveryErrors(unittest.TestCase):
       build(
         'plus', 'v1', http=http, credentials=mock.sentinel.credentials)
 
+  def test_credentials_and_developer_key_mutually_exclusive(self):
+    http = HttpMock(datafile('plus.json'), {'status': '200'})
+    with self.assertRaises(ValueError):
+      build(
+        'plus', 'v1', credentials=mock.sentinel.credentials,
+        developerKey=mock.sentinel.credentials)
+
 
 class DiscoveryFromDocument(unittest.TestCase):
   MOCK_CREDENTIALS = mock.Mock(spec=google.auth.credentials.Credentials)


### PR DESCRIPTION
Fixes #357