### PR TITLE
ZeroDivisionError when calling 'MediaDownloadProgress.progress'

### DIFF
--- a/googleapiclient/http.py
+++ b/googleapiclient/http.py
@@ -203,7 +203,7 @@ class MediaUploadProgress(object):
       the percentage complete as a float, returning 0.0 if the total size of
       the upload is unknown.
     """
-    if self.total_size is not None:
+    if self.total_size is not None and self.total_size != 0:
       return float(self.resumable_progress) / float(self.total_size)
     else:
       return 0.0
@@ -229,7 +229,7 @@ class MediaDownloadProgress(object):
       the percentage complete as a float, returning 0.0 if the total size of
       the download is unknown.
     """
-    if self.total_size is not None:
+    if self.total_size is not None and self.total_size != 0:
       return float(self.resumable_progress) / float(self.total_size)
     else:
       return 0.0

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -550,6 +550,28 @@ class TestMediaIoBaseDownload(unittest.TestCase):
     self.assertEqual(5, download._progress)
     self.assertEqual(5, download._total_size)
 
+  def test_media_io_base_download_empty_file(self):
+    self.request.http = HttpMockSequence([
+      ({'status': '200',
+        'content-range': '0-0/0'}, b''),
+    ])
+
+    download = MediaIoBaseDownload(
+      fd=self.fd, request=self.request, chunksize=3)
+
+    self.assertEqual(self.fd, download._fd)
+    self.assertEqual(0, download._progress)
+    self.assertEqual(None, download._total_size)
+    self.assertEqual(False, download._done)
+    self.assertEqual(self.request.uri, download._uri)
+
+    status, done = download.next_chunk()
+
+    self.assertEqual(True, done)
+    self.assertEqual(0, download._progress)
+    self.assertEqual(0, download._total_size)
+    self.assertEqual(0, status.progress())
+
 EXPECTED = """POST /someapi/v1/collection/?foo=bar HTTP/1.1
 Content-Type: application/json
 MIME-Version: 1.0


### PR DESCRIPTION
Applies also for `MediaUploadProgress`.

Resolves: #369