### PR TITLE
Add the error details in HttpError if exists

### DIFF
--- a/googleapiclient/errors.py
+++ b/googleapiclient/errors.py
@@ -26,128 +26,138 @@ import json
 # Oauth2client < 3 has the positional helper in 'util', >= 3 has it
 # in '_helpers'.
 try:
-  from oauth2client import util
+    from oauth2client import util
 except ImportError:
-  from oauth2client import _helpers as util
+    from oauth2client import _helpers as util
 
 
 class Error(Exception):
-  """Base error for this module."""
-  pass
+    """Base error for this module."""
+    pass
 
 
 class HttpError(Error):
-  """HTTP data was invalid or unexpected."""
+    """HTTP data was invalid or unexpected."""
 
-  @util.positional(3)
-  def __init__(self, resp, content, uri=None):
-    self.resp = resp
-    if not isinstance(content, bytes):
-        raise TypeError("HTTP content should be bytes")
-    self.content = content
-    self.uri = uri
+    @util.positional(3)
+    def __init__(self, resp, content, uri=None):
+        self.resp = resp
+        if not isinstance(content, bytes):
+            raise TypeError("HTTP content should be bytes")
+        self.content = content
+        self.uri = uri
+        self.error_details = ''
 
-  def _get_reason(self):
-    """Calculate the reason for the error from the response content."""
-    reason = self.resp.reason
-    try:
-      data = json.loads(self.content.decode('utf-8'))
-      if isinstance(data, dict):
-        reason = data['error']['message']
-      elif isinstance(data, list) and len(data) > 0:
-        first_error = data[0]
-        reason = first_error['error']['message']
-    except (ValueError, KeyError, TypeError):
-      pass
-    if reason is None:
-      reason = ''
-    return reason
+    def _get_reason(self):
+        """Calculate the reason for the error from the response content."""
+        reason = self.resp.reason
+        try:
+            data = json.loads(self.content.decode('utf-8'))
+            if isinstance(data, dict):
+                reason = data['error']['message']
+                if 'details' in data['error']:
+                    self.error_details = data['error']['details']
+            elif isinstance(data, list) and len(data) > 0:
+                first_error = data[0]
+                reason = first_error['error']['message']
+                if 'details' in first_error['error']:
+                    self.error_details = first_error['error']['details']
+        except (ValueError, KeyError, TypeError):
+            pass
+        if reason is None:
+            reason = ''
+        return reason
 
-  def __repr__(self):
-    if self.uri:
-      return '<HttpError %s when requesting %s returned "%s">' % (
-          self.resp.status, self.uri, self._get_reason().strip())
-    else:
-      return '<HttpError %s "%s">' % (self.resp.status, self._get_reason())
+    def __repr__(self):
+        if self.error_details:
+            return '<HttpError %s when requesting %s returned "%s". Details: "%s">' % (
+                self.resp.status, self.uri, self._get_reason().strip(), self.error_details)
+        elif self.uri:
+            return '<HttpError %s when requesting %s returned "%s">' % (
+                self.resp.status, self.uri, self._get_reason().strip())
+        else:
+            return '<HttpError %s "%s">' % (self.resp.status, self._get_reason())
 
-  __str__ = __repr__
+    __str__ = __repr__
 
 
 class InvalidJsonError(Error):
-  """The JSON returned could not be parsed."""
-  pass
+    """The JSON returned could not be parsed."""
+    pass
 
 
 class UnknownFileType(Error):
-  """File type unknown or unexpected."""
-  pass
+    """File type unknown or unexpected."""
+    pass
 
 
 class UnknownLinkType(Error):
-  """Link type unknown or unexpected."""
-  pass
+    """Link type unknown or unexpected."""
+    pass
 
 
 class UnknownApiNameOrVersion(Error):
-  """No API with that name and version exists."""
-  pass
+    """No API with that name and version exists."""
+    pass
 
 
 class UnacceptableMimeTypeError(Error):
-  """That is an unacceptable mimetype for this operation."""
-  pass
+    """That is an unacceptable mimetype for this operation."""
+    pass
 
 
 class MediaUploadSizeError(Error):
-  """Media is larger than the method can accept."""
-  pass
+    """Media is larger than the method can accept."""
+    pass
 
 
 class ResumableUploadError(HttpError):
-  """Error occured during resumable upload."""
-  pass
+    """Error occured during resumable upload."""
+    pass
 
 
 class InvalidChunkSizeError(Error):
-  """The given chunksize is not valid."""
-  pass
+    """The given chunksize is not valid."""
+    pass
+
 
 class InvalidNotificationError(Error):
-  """The channel Notification is invalid."""
-  pass
+    """The channel Notification is invalid."""
+    pass
+
 
 class BatchError(HttpError):
-  """Error occured during batch operations."""
+    """Error occured during batch operations."""
 
-  @util.positional(2)
-  def __init__(self, reason, resp=None, content=None):
-    self.resp = resp
-    self.content = content
-    self.reason = reason
+    @util.positional(2)
+    def __init__(self, reason, resp=None, content=None):
+        self.resp = resp
+        self.content = content
+        self.reason = reason
 
-  def __repr__(self):
-    if getattr(self.resp, 'status', None) is None:
-      return '<BatchError "%s">' % (self.reason)
-    else:
-      return '<BatchError %s "%s">' % (self.resp.status, self.reason)
+    def __repr__(self):
+        if getattr(self.resp, 'status', None) is None:
+            return '<BatchError "%s">' % (self.reason)
+        else:
+            return '<BatchError %s "%s">' % (self.resp.status, self.reason)
 
-  __str__ = __repr__
+    __str__ = __repr__
 
 
 class UnexpectedMethodError(Error):
-  """Exception raised by RequestMockBuilder on unexpected calls."""
+    """Exception raised by RequestMockBuilder on unexpected calls."""
 
-  @util.positional(1)
-  def __init__(self, methodId=None):
-    """Constructor for an UnexpectedMethodError."""
-    super(UnexpectedMethodError, self).__init__(
-        'Received unexpected call %s' % methodId)
+    @util.positional(1)
+    def __init__(self, methodId=None):
+        """Constructor for an UnexpectedMethodError."""
+        super(UnexpectedMethodError, self).__init__(
+            'Received unexpected call %s' % methodId)
 
 
 class UnexpectedBodyError(Error):
-  """Exception raised by RequestMockBuilder on unexpected bodies."""
+    """Exception raised by RequestMockBuilder on unexpected bodies."""
 
-  def __init__(self, expected, provided):
-    """Constructor for an UnexpectedMethodError."""
-    super(UnexpectedBodyError, self).__init__(
-        'Expected: [%s] - Provided: [%s]' % (expected, provided))
+    def __init__(self, expected, provided):
+        """Constructor for an UnexpectedMethodError."""
+        super(UnexpectedBodyError, self).__init__(
+            'Expected: [%s] - Provided: [%s]' % (expected, provided))

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -20,13 +20,10 @@ from __future__ import absolute_import
 
 __author__ = 'afshar@google.com (Ali Afshar)'
 
-
 import unittest2 as unittest
 import httplib2
 
-
 from googleapiclient.errors import HttpError
-
 
 JSON_ERROR_CONTENT = b"""
 {
@@ -41,59 +38,68 @@ JSON_ERROR_CONTENT = b"""
    }
   ],
   "code": 400,
-  "message": "country is required"
+  "message": "country is required",
+  "details": "error details"
  }
 }
 """
 
+
 def fake_response(data, headers, reason='Ok'):
-  response = httplib2.Response(headers)
-  response.reason = reason
-  return response, data
+    response = httplib2.Response(headers)
+    response.reason = reason
+    return response, data
 
 
 class Error(unittest.TestCase):
-  """Test handling of error bodies."""
+    """Test handling of error bodies."""
 
-  def test_json_body(self):
+
+def test_json_body(self):
     """Test a nicely formed, expected error response."""
     resp, content = fake_response(JSON_ERROR_CONTENT,
-        {'status':'400', 'content-type': 'application/json'},
-        reason='Failed')
+                                  {'status': '400', 'content-type': 'application/json'},
+                                  reason='Failed')
     error = HttpError(resp, content, uri='http://example.org')
-    self.assertEqual(str(error), '<HttpError 400 when requesting http://example.org returned "country is required">')
+    self.assertEqual(str(error),
+                     '<HttpError 400 when requesting http://example.org returned "country is required". Details: "error details">')
 
-  def test_bad_json_body(self):
+
+def test_bad_json_body(self):
     """Test handling of bodies with invalid json."""
     resp, content = fake_response(b'{',
-        { 'status':'400', 'content-type': 'application/json'},
-        reason='Failed')
+                                  {'status': '400', 'content-type': 'application/json'},
+                                  reason='Failed')
     error = HttpError(resp, content)
     self.assertEqual(str(error), '<HttpError 400 "Failed">')
 
-  def test_with_uri(self):
+
+def test_with_uri(self):
     """Test handling of passing in the request uri."""
     resp, content = fake_response(b'{',
-        {'status':'400', 'content-type': 'application/json'},
-        reason='Failure')
+                                  {'status': '400', 'content-type': 'application/json'},
+                                  reason='Failure')
     error = HttpError(resp, content, uri='http://example.org')
     self.assertEqual(str(error), '<HttpError 400 when requesting http://example.org returned "Failure">')
 
-  def test_missing_message_json_body(self):
+
+def test_missing_message_json_body(self):
     """Test handling of bodies with missing expected 'message' element."""
     resp, content = fake_response(b'{}',
-        {'status':'400', 'content-type': 'application/json'},
-        reason='Failed')
+                                  {'status': '400', 'content-type': 'application/json'},
+                                  reason='Failed')
     error = HttpError(resp, content)
     self.assertEqual(str(error), '<HttpError 400 "Failed">')
 
-  def test_non_json(self):
+
+def test_non_json(self):
     """Test handling of non-JSON bodies"""
-    resp, content = fake_response(b'}NOT OK', {'status':'400'})
+    resp, content = fake_response(b'}NOT OK', {'status': '400'})
     error = HttpError(resp, content)
     self.assertEqual(str(error), '<HttpError 400 "Ok">')
 
-  def test_missing_reason(self):
+
+def test_missing_reason(self):
     """Test an empty dict with a missing resp.reason."""
     resp, content = fake_response(b'}NOT OK', {'status': '400'}, reason=None)
     error = HttpError(resp, content)


### PR DESCRIPTION
For instance, the HttpError returns only the message and the status code. So, adding the error details on googleapiclient.errors.HttpError would be useful. If the error body contains the "details" field, just show it together with the error message.

Resolves: #382