### PR TITLE
BatchHTTPRequest: only add access token header if we have it

### DIFF
--- a/googleapiclient/http.py
+++ b/googleapiclient/http.py
@@ -1207,7 +1207,7 @@ class BatchHttpRequest(object):
 
     if request.http is not None:
       credentials = _auth.get_credentials_from_http(request.http)
-      if credentials is not None:
+      if credentials is not None and getattr(credentials, 'access_token', None):
         _auth.apply_credentials(credentials, headers)
 
     # MIMENonMultipart adds its own Content-Type header.


### PR DESCRIPTION
re-fixes #350. it was originally fixed by c669a3b9a89402c14179d11e587f5438b7209b5c following discussion in https://github.com/google/google-api-python-client/pull/351#discussion_r101218589 , but then that fix got lost in the next commit, https://github.com/google/google-api-python-client/pull/376/commits/282fc889956e42de8ec3e26aecbe39509f027333 .