### PR TITLE
Allow http+credentials in build_from_document.

### DIFF
--- a/googleapiclient/_auth.py
+++ b/googleapiclient/_auth.py
@@ -72,26 +72,29 @@ def with_scopes(credentials, scopes):
             return credentials
 
 
-def authorized_http(credentials):
+def authorized_http(credentials, http=None):
     """Returns an http client that is authorized with the given credentials.
 
     Args:
         credentials (Union[
             google.auth.credentials.Credentials,
             oauth2client.client.Credentials]): The credentials to use.
+        http (httplib2.Http): A httplib2 object or one similar enough to
+            provide authentication and tansport interfaces.
 
     Returns:
         Union[httplib2.Http, google_auth_httplib2.AuthorizedHttp]: An
             authorized http client.
     """
-    from googleapiclient.http import build_http
+    if http is None:
+      from googleapiclient.http import build_http
+      http = build_http()
 
     if HAS_GOOGLE_AUTH and isinstance(
             credentials, google.auth.credentials.Credentials):
-        return google_auth_httplib2.AuthorizedHttp(credentials,
-                                                   http=build_http())
+        return google_auth_httplib2.AuthorizedHttp(credentials, http=http)
     else:
-        return credentials.authorize(build_http())
+        return credentials.authorize(http)
 
 
 def refresh_credentials(credentials):

--- a/googleapiclient/discovery.py
+++ b/googleapiclient/discovery.py
@@ -331,9 +331,6 @@ def build_from_document(
     A Resource object with methods for interacting with the service.
   """
 
-  if http is not None and credentials is not None:
-    raise ValueError('Arguments http and credentials are mutually exclusive.')
-
   if developerKey is not None and credentials is not None:
     raise ValueError(
       'Arguments developerKey and credentials are mutually exclusive.')
@@ -352,37 +349,24 @@ def build_from_document(
   base = urljoin(service['rootUrl'], service['servicePath'])
   schema = Schemas(service)
 
-  # If the http client is not specified, then we must construct an http client
-  # to make requests. If the service has scopes, then we also need to setup
-  # authentication.
   if http is None:
-    # Does the service require scopes?
+    http = build_http()
+
+  # If the service has scopes, then we also need to setup authentication.
+  if credentials:
     scopes = list(
       service.get('auth', {}).get('oauth2', {}).get('scopes', {}).keys())
-
-    # If so, then the we need to setup authentication if no developerKey is
-    # specified.
-    if scopes and not developerKey:
-      # If the user didn't pass in credentials, attempt to acquire application
-      # default credentials.
-      if credentials is None:
-        credentials = _auth.default_credentials()
-
+    if not scopes:
+      credentials = None
+    elif scopes and not developerKey:
       # The credentials need to be scoped.
       credentials = _auth.with_scopes(credentials, scopes)
-
       # Create an authorized http instance
-      http = _auth.authorized_http(credentials)
-
-    # If the service doesn't require scopes then there is no need for
-    # authentication.
-    else:
-      http = build_http()
+      http = _auth.authorized_http(credentials, http)
 
   if model is None:
     features = service.get('features', [])
     model = JsonModel('dataWrapper' in features)
-
   return Resource(http=http, baseUrl=base, model=model,
                   developerKey=developerKey, requestBuilder=requestBuilder,
                   resourceDesc=service, rootDesc=service, schema=schema)


### PR DESCRIPTION
1) Prevent the passing of http and credentials to build_from_document
    from raising a ValueError.
2) End the behavior where credentials will be auto-created if none are
   provided. As far as I can tell, this new behavior is not documented
   anywhere and it breaks api compatibility between the 1.5 and 1.6
   releases. This is also preventing a migration I am working on involving
   a larger-ish code base that relies on the established behavior for testing.