### PR TITLE
Add convenience function to build subresource clients in one request

### DIFF
--- a/tests/data/iam.json
+++ b/tests/data/iam.json
@@ -1,0 +1,1970 @@
+{
+    "name":"iam",
+    "canonicalName":"iam",
+    "id":"iam:v1",
+    "ownerDomain":"google.com",
+    "basePath":"",
+    "protocol":"rest",
+    "revision":"20171228",
+    "icons":{
+        "x16":"http://www.google.com/images/icons/product/search-16.gif",
+        "x32":"http://www.google.com/images/icons/product/search-32.gif"
+    },
+    "discoveryVersion":"v1",
+    "parameters":{
+        "bearer_token":{
+            "type":"string",
+            "location":"query",
+            "description":"OAuth bearer token."
+        },
+        "callback":{
+            "type":"string",
+            "description":"JSONP",
+            "location":"query"
+        },
+        "uploadType":{
+            "type":"string",
+            "description":"Legacy upload protocol for media (e.g. \"media\", \"multipart\").",
+            "location":"query"
+        },
+        "prettyPrint":{
+            "type":"boolean",
+            "description":"Returns response with indentations and line breaks.",
+            "location":"query",
+            "default":"true"
+        },
+        "upload_protocol":{
+            "type":"string",
+            "location":"query",
+            "description":"Upload protocol for media (e.g. \"raw\", \"multipart\")."
+        },
+        "oauth_token":{
+            "type":"string",
+            "description":"OAuth 2.0 token for the current user.",
+            "location":"query"
+        },
+        "alt":{
+            "default":"json",
+            "description":"Data format for response.",
+            "enum":[
+                "json",
+                "media",
+                "proto"
+            ],
+            "type":"string",
+            "enumDescriptions":[
+                "Responses with Content-Type of application/json",
+                "Media download with context-dependent Content-Type",
+                "Responses with Content-Type of application/x-protobuf"
+            ],
+            "location":"query"
+        },
+        "fields":{
+            "type":"string",
+            "description":"Selector specifying which fields to include in a partial response.",
+            "location":"query"
+        },
+        "access_token":{
+            "type":"string",
+            "location":"query",
+            "description":"OAuth access token."
+        },
+        "quotaUser":{
+            "type":"string",
+            "description":"Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.",
+            "location":"query"
+        },
+        "$.xgafv":{
+            "enum":[
+                "1",
+                "2"
+            ],
+            "type":"string",
+            "location":"query",
+            "enumDescriptions":[
+                "v1 error format",
+                "v2 error format"
+            ],
+            "description":"V1 error format."
+        },
+        "pp":{
+            "type":"boolean",
+            "description":"Pretty-print response.",
+            "location":"query",
+            "default":"true"
+        },
+        "key":{
+            "type":"string",
+            "location":"query",
+            "description":"API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token."
+        }
+    },
+    "kind":"discovery#restDescription",
+    "rootUrl":"https://iam.googleapis.com/",
+    "documentationLink":"https://cloud.google.com/iam/",
+    "baseUrl":"https://iam.googleapis.com/",
+    "auth":{
+        "oauth2":{
+            "scopes":{
+                "https://www.googleapis.com/auth/cloud-platform":{
+                    "description":"View and manage your data across Google Cloud Platform services"
+                }
+            }
+        }
+    },
+    "resources":{
+        "organizations":{
+            "resources":{
+                "roles":{
+                    "methods":{
+                        "undelete":{
+                            "response":{
+                                "$ref":"Role"
+                            },
+                            "flatPath":"v1/organizations/{organizationsId}/roles/{rolesId}:undelete",
+                            "id":"iam.organizations.roles.undelete",
+                            "description":"Undelete a Role, bringing it back in its previous state.",
+                            "parameterOrder":[
+                                "name"
+                            ],
+                            "path":"v1/{+name}:undelete",
+                            "request":{
+                                "$ref":"UndeleteRoleRequest"
+                            },
+                            "httpMethod":"POST",
+                            "scopes":[
+                                "https://www.googleapis.com/auth/cloud-platform"
+                            ],
+                            "parameters":{
+                                "name":{
+                                    "pattern":"^organizations/[^/]+/roles/[^/]+$",
+                                    "type":"string",
+                                    "required":true,
+                                    "description":"The resource name of the role in one of the following formats:\n`organizations/{ORGANIZATION_ID}/roles/{ROLE_NAME}`\n`projects/{PROJECT_ID}/roles/{ROLE_NAME}`",
+                                    "location":"path"
+                                }
+                            }
+                        },
+                        "patch":{
+                            "response":{
+                                "$ref":"Role"
+                            },
+                            "flatPath":"v1/organizations/{organizationsId}/roles/{rolesId}",
+                            "id":"iam.organizations.roles.patch",
+                            "description":"Updates a Role definition.",
+                            "parameterOrder":[
+                                "name"
+                            ],
+                            "path":"v1/{+name}",
+                            "request":{
+                                "$ref":"Role"
+                            },
+                            "httpMethod":"PATCH",
+                            "scopes":[
+                                "https://www.googleapis.com/auth/cloud-platform"
+                            ],
+                            "parameters":{
+                                "name":{
+                                    "pattern":"^organizations/[^/]+/roles/[^/]+$",
+                                    "type":"string",
+                                    "required":true,
+                                    "description":"The resource name of the role in one of the following formats:\n`roles/{ROLE_NAME}`\n`organizations/{ORGANIZATION_ID}/roles/{ROLE_NAME}`\n`projects/{PROJECT_ID}/roles/{ROLE_NAME}`",
+                                    "location":"path"
+                                },
+                                "updateMask":{
+                                    "type":"string",
+                                    "format":"google-fieldmask",
+                                    "description":"A mask describing which fields in the Role have changed.",
+                                    "location":"query"
+                                }
+                            }
+                        },
+                        "delete":{
+                            "response":{
+                                "$ref":"Role"
+                            },
+                            "flatPath":"v1/organizations/{organizationsId}/roles/{rolesId}",
+                            "id":"iam.organizations.roles.delete",
+                            "description":"Soft deletes a role. The role is suspended and cannot be used to create new\nIAM Policy Bindings.\nThe Role will not be included in `ListRoles()` unless `show_deleted` is set\nin the `ListRolesRequest`. The Role contains the deleted boolean set.\nExisting Bindings remains, but are inactive. The Role can be undeleted\nwithin 7 days. After 7 days the Role is deleted and all Bindings associated\nwith the role are removed.",
+                            "parameterOrder":[
+                                "name"
+                            ],
+                            "path":"v1/{+name}",
+                            "httpMethod":"DELETE",
+                            "scopes":[
+                                "https://www.googleapis.com/auth/cloud-platform"
+                            ],
+                            "parameters":{
+                                "name":{
+                                    "pattern":"^organizations/[^/]+/roles/[^/]+$",
+                                    "type":"string",
+                                    "required":true,
+                                    "description":"The resource name of the role in one of the following formats:\n`organizations/{ORGANIZATION_ID}/roles/{ROLE_NAME}`\n`projects/{PROJECT_ID}/roles/{ROLE_NAME}`",
+                                    "location":"path"
+                                },
+                                "etag":{
+                                    "type":"string",
+                                    "format":"byte",
+                                    "location":"query",
+                                    "description":"Used to perform a consistent read-modify-write."
+                                }
+                            }
+                        },
+                        "get":{
+                            "response":{
+                                "$ref":"Role"
+                            },
+                            "flatPath":"v1/organizations/{organizationsId}/roles/{rolesId}",
+                            "id":"iam.organizations.roles.get",
+                            "description":"Gets a Role definition.",
+                            "parameterOrder":[
+                                "name"
+                            ],
+                            "path":"v1/{+name}",
+                            "httpMethod":"GET",
+                            "scopes":[
+                                "https://www.googleapis.com/auth/cloud-platform"
+                            ],
+                            "parameters":{
+                                "name":{
+                                    "pattern":"^organizations/[^/]+/roles/[^/]+$",
+                                    "type":"string",
+                                    "required":true,
+                                    "location":"path",
+                                    "description":"The resource name of the role in one of the following formats:\n`roles/{ROLE_NAME}`\n`organizations/{ORGANIZATION_ID}/roles/{ROLE_NAME}`\n`projects/{PROJECT_ID}/roles/{ROLE_NAME}`"
+                                }
+                            }
+                        },
+                        "create":{
+                            "response":{
+                                "$ref":"Role"
+                            },
+                            "flatPath":"v1/organizations/{organizationsId}/roles",
+                            "id":"iam.organizations.roles.create",
+                            "description":"Creates a new Role.",
+                            "parameterOrder":[
+                                "parent"
+                            ],
+                            "path":"v1/{+parent}/roles",
+                            "request":{
+                                "$ref":"CreateRoleRequest"
+                            },
+                            "httpMethod":"POST",
+                            "scopes":[
+                                "https://www.googleapis.com/auth/cloud-platform"
+                            ],
+                            "parameters":{
+                                "parent":{
+                                    "pattern":"^organizations/[^/]+$",
+                                    "type":"string",
+                                    "required":true,
+                                    "description":"The resource name of the parent resource in one of the following formats:\n`organizations/{ORGANIZATION_ID}`\n`projects/{PROJECT_ID}`",
+                                    "location":"path"
+                                }
+                            }
+                        },
+                        "list":{
+                            "response":{
+                                "$ref":"ListRolesResponse"
+                            },
+                            "flatPath":"v1/organizations/{organizationsId}/roles",
+                            "id":"iam.organizations.roles.list",
+                            "description":"Lists the Roles defined on a resource.",
+                            "parameterOrder":[
+                                "parent"
+                            ],
+                            "path":"v1/{+parent}/roles",
+                            "httpMethod":"GET",
+                            "scopes":[
+                                "https://www.googleapis.com/auth/cloud-platform"
+                            ],
+                            "parameters":{
+                                "pageToken":{
+                                    "type":"string",
+                                    "location":"query",
+                                    "description":"Optional pagination token returned in an earlier ListRolesResponse."
+                                },
+                                "view":{
+                                    "enum":[
+                                        "BASIC",
+                                        "FULL"
+                                    ],
+                                    "type":"string",
+                                    "description":"Optional view for the returned Role objects.",
+                                    "location":"query"
+                                },
+                                "showDeleted":{
+                                    "type":"boolean",
+                                    "description":"Include Roles that have been deleted.",
+                                    "location":"query"
+                                },
+                                "pageSize":{
+                                    "type":"integer",
+                                    "format":"int32",
+                                    "description":"Optional limit on the number of roles to include in the response.",
+                                    "location":"query"
+                                },
+                                "parent":{
+                                    "pattern":"^organizations/[^/]+$",
+                                    "type":"string",
+                                    "required":true,
+                                    "location":"path",
+                                    "description":"The resource name of the parent resource in one of the following formats:\n`` (empty string) -- this refers to curated roles.\n`organizations/{ORGANIZATION_ID}`\n`projects/{PROJECT_ID}`"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "projects":{
+            "resources":{
+                "serviceAccounts":{
+                    "resources":{
+                        "keys":{
+                            "methods":{
+                                "delete":{
+                                    "response":{
+                                        "$ref":"Empty"
+                                    },
+                                    "flatPath":"v1/projects/{projectsId}/serviceAccounts/{serviceAccountsId}/keys/{keysId}",
+                                    "id":"iam.projects.serviceAccounts.keys.delete",
+                                    "description":"Deletes a ServiceAccountKey.",
+                                    "parameterOrder":[
+                                        "name"
+                                    ],
+                                    "path":"v1/{+name}",
+                                    "httpMethod":"DELETE",
+                                    "scopes":[
+                                        "https://www.googleapis.com/auth/cloud-platform"
+                                    ],
+                                    "parameters":{
+                                        "name":{
+                                            "pattern":"^projects/[^/]+/serviceAccounts/[^/]+/keys/[^/]+$",
+                                            "type":"string",
+                                            "required":true,
+                                            "location":"path",
+                                            "description":"The resource name of the service account key in the following format:\n`projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}/keys/{key}`.\nUsing `-` as a wildcard for the `PROJECT_ID` will infer the project from\nthe account. The `ACCOUNT` value can be the `email` address or the\n`unique_id` of the service account."
+                                        }
+                                    }
+                                },
+                                "get":{
+                                    "response":{
+                                        "$ref":"ServiceAccountKey"
+                                    },
+                                    "flatPath":"v1/projects/{projectsId}/serviceAccounts/{serviceAccountsId}/keys/{keysId}",
+                                    "id":"iam.projects.serviceAccounts.keys.get",
+                                    "description":"Gets the ServiceAccountKey\nby key id.",
+                                    "parameterOrder":[
+                                        "name"
+                                    ],
+                                    "path":"v1/{+name}",
+                                    "httpMethod":"GET",
+                                    "scopes":[
+                                        "https://www.googleapis.com/auth/cloud-platform"
+                                    ],
+                                    "parameters":{
+                                        "publicKeyType":{
+                                            "enum":[
+                                                "TYPE_NONE",
+                                                "TYPE_X509_PEM_FILE",
+                                                "TYPE_RAW_PUBLIC_KEY"
+                                            ],
+                                            "type":"string",
+                                            "description":"The output format of the public key requested.\nX509_PEM is the default output format.",
+                                            "location":"query"
+                                        },
+                                        "name":{
+                                            "pattern":"^projects/[^/]+/serviceAccounts/[^/]+/keys/[^/]+$",
+                                            "type":"string",
+                                            "required":true,
+                                            "location":"path",
+                                            "description":"The resource name of the service account key in the following format:\n`projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}/keys/{key}`.\n\nUsing `-` as a wildcard for the `PROJECT_ID` will infer the project from\nthe account. The `ACCOUNT` value can be the `email` address or the\n`unique_id` of the service account."
+                                        }
+                                    }
+                                },
+                                "create":{
+                                    "response":{
+                                        "$ref":"ServiceAccountKey"
+                                    },
+                                    "flatPath":"v1/projects/{projectsId}/serviceAccounts/{serviceAccountsId}/keys",
+                                    "id":"iam.projects.serviceAccounts.keys.create",
+                                    "description":"Creates a ServiceAccountKey\nand returns it.",
+                                    "parameterOrder":[
+                                        "name"
+                                    ],
+                                    "path":"v1/{+name}/keys",
+                                    "request":{
+                                        "$ref":"CreateServiceAccountKeyRequest"
+                                    },
+                                    "httpMethod":"POST",
+                                    "scopes":[
+                                        "https://www.googleapis.com/auth/cloud-platform"
+                                    ],
+                                    "parameters":{
+                                        "name":{
+                                            "pattern":"^projects/[^/]+/serviceAccounts/[^/]+$",
+                                            "type":"string",
+                                            "required":true,
+                                            "description":"The resource name of the service account in the following format:\n`projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}`.\nUsing `-` as a wildcard for the `PROJECT_ID` will infer the project from\nthe account. The `ACCOUNT` value can be the `email` address or the\n`unique_id` of the service account.",
+                                            "location":"path"
+                                        }
+                                    }
+                                },
+                                "list":{
+                                    "response":{
+                                        "$ref":"ListServiceAccountKeysResponse"
+                                    },
+                                    "flatPath":"v1/projects/{projectsId}/serviceAccounts/{serviceAccountsId}/keys",
+                                    "id":"iam.projects.serviceAccounts.keys.list",
+                                    "description":"Lists ServiceAccountKeys.",
+                                    "parameterOrder":[
+                                        "name"
+                                    ],
+                                    "path":"v1/{+name}/keys",
+                                    "httpMethod":"GET",
+                                    "scopes":[
+                                        "https://www.googleapis.com/auth/cloud-platform"
+                                    ],
+                                    "parameters":{
+                                        "name":{
+                                            "pattern":"^projects/[^/]+/serviceAccounts/[^/]+$",
+                                            "type":"string",
+                                            "required":true,
+                                            "location":"path",
+                                            "description":"The resource name of the service account in the following format:\n`projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}`.\n\nUsing `-` as a wildcard for the `PROJECT_ID`, will infer the project from\nthe account. The `ACCOUNT` value can be the `email` address or the\n`unique_id` of the service account."
+                                        },
+                                        "keyTypes":{
+                                            "enum":[
+                                                "KEY_TYPE_UNSPECIFIED",
+                                                "USER_MANAGED",
+                                                "SYSTEM_MANAGED"
+                                            ],
+                                            "repeated":true,
+                                            "type":"string",
+                                            "description":"Filters the types of keys the user wants to include in the list\nresponse. Duplicate key types are not allowed. If no key type\nis provided, all keys are returned.",
+                                            "location":"query"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "methods":{
+                        "testIamPermissions":{
+                            "response":{
+                                "$ref":"TestIamPermissionsResponse"
+                            },
+                            "flatPath":"v1/projects/{projectsId}/serviceAccounts/{serviceAccountsId}:testIamPermissions",
+                            "id":"iam.projects.serviceAccounts.testIamPermissions",
+                            "description":"Tests the specified permissions against the IAM access control policy\nfor a ServiceAccount.",
+                            "parameterOrder":[
+                                "resource"
+                            ],
+                            "path":"v1/{+resource}:testIamPermissions",
+                            "request":{
+                                "$ref":"TestIamPermissionsRequest"
+                            },
+                            "httpMethod":"POST",
+                            "scopes":[
+                                "https://www.googleapis.com/auth/cloud-platform"
+                            ],
+                            "parameters":{
+                                "resource":{
+                                    "pattern":"^projects/[^/]+/serviceAccounts/[^/]+$",
+                                    "type":"string",
+                                    "required":true,
+                                    "location":"path",
+                                    "description":"REQUIRED: The resource for which the policy detail is being requested.\nSee the operation documentation for the appropriate value for this field."
+                                }
+                            }
+                        },
+                        "signJwt":{
+                            "response":{
+                                "$ref":"SignJwtResponse"
+                            },
+                            "flatPath":"v1/projects/{projectsId}/serviceAccounts/{serviceAccountsId}:signJwt",
+                            "id":"iam.projects.serviceAccounts.signJwt",
+                            "description":"Signs a JWT using a service account's system-managed private key.\n\nIf no expiry time (`exp`) is provided in the `SignJwtRequest`, IAM sets an\nan expiry time of one hour by default. If you request an expiry time of\nmore than one hour, the request will fail.",
+                            "parameterOrder":[
+                                "name"
+                            ],
+                            "path":"v1/{+name}:signJwt",
+                            "request":{
+                                "$ref":"SignJwtRequest"
+                            },
+                            "httpMethod":"POST",
+                            "scopes":[
+                                "https://www.googleapis.com/auth/cloud-platform"
+                            ],
+                            "parameters":{
+                                "name":{
+                                    "pattern":"^projects/[^/]+/serviceAccounts/[^/]+$",
+                                    "type":"string",
+                                    "required":true,
+                                    "location":"path",
+                                    "description":"The resource name of the service account in the following format:\n`projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}`.\nUsing `-` as a wildcard for the `PROJECT_ID` will infer the project from\nthe account. The `ACCOUNT` value can be the `email` address or the\n`unique_id` of the service account."
+                                }
+                            }
+                        },
+                        "signBlob":{
+                            "response":{
+                                "$ref":"SignBlobResponse"
+                            },
+                            "flatPath":"v1/projects/{projectsId}/serviceAccounts/{serviceAccountsId}:signBlob",
+                            "id":"iam.projects.serviceAccounts.signBlob",
+                            "description":"Signs a blob using a service account's system-managed private key.",
+                            "parameterOrder":[
+                                "name"
+                            ],
+                            "path":"v1/{+name}:signBlob",
+                            "request":{
+                                "$ref":"SignBlobRequest"
+                            },
+                            "httpMethod":"POST",
+                            "scopes":[
+                                "https://www.googleapis.com/auth/cloud-platform"
+                            ],
+                            "parameters":{
+                                "name":{
+                                    "pattern":"^projects/[^/]+/serviceAccounts/[^/]+$",
+                                    "type":"string",
+                                    "required":true,
+                                    "location":"path",
+                                    "description":"The resource name of the service account in the following format:\n`projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}`.\nUsing `-` as a wildcard for the `PROJECT_ID` will infer the project from\nthe account. The `ACCOUNT` value can be the `email` address or the\n`unique_id` of the service account."
+                                }
+                            }
+                        },
+                        "setIamPolicy":{
+                            "response":{
+                                "$ref":"Policy"
+                            },
+                            "flatPath":"v1/projects/{projectsId}/serviceAccounts/{serviceAccountsId}:setIamPolicy",
+                            "id":"iam.projects.serviceAccounts.setIamPolicy",
+                            "description":"Sets the IAM access control policy for a\nServiceAccount.",
+                            "parameterOrder":[
+                                "resource"
+                            ],
+                            "path":"v1/{+resource}:setIamPolicy",
+                            "request":{
+                                "$ref":"SetIamPolicyRequest"
+                            },
+                            "httpMethod":"POST",
+                            "scopes":[
+                                "https://www.googleapis.com/auth/cloud-platform"
+                            ],
+                            "parameters":{
+                                "resource":{
+                                    "pattern":"^projects/[^/]+/serviceAccounts/[^/]+$",
+                                    "type":"string",
+                                    "required":true,
+                                    "location":"path",
+                                    "description":"REQUIRED: The resource for which the policy is being specified.\nSee the operation documentation for the appropriate value for this field."
+                                }
+                            }
+                        },
+                        "list":{
+                            "response":{
+                                "$ref":"ListServiceAccountsResponse"
+                            },
+                            "flatPath":"v1/projects/{projectsId}/serviceAccounts",
+                            "id":"iam.projects.serviceAccounts.list",
+                            "description":"Lists ServiceAccounts for a project.",
+                            "parameterOrder":[
+                                "name"
+                            ],
+                            "path":"v1/{+name}/serviceAccounts",
+                            "httpMethod":"GET",
+                            "scopes":[
+                                "https://www.googleapis.com/auth/cloud-platform"
+                            ],
+                            "parameters":{
+                                "name":{
+                                    "pattern":"^projects/[^/]+$",
+                                    "type":"string",
+                                    "required":true,
+                                    "description":"Required. The resource name of the project associated with the service\naccounts, such as `projects/my-project-123`.",
+                                    "location":"path"
+                                },
+                                "pageToken":{
+                                    "type":"string",
+                                    "location":"query",
+                                    "description":"Optional pagination token returned in an earlier\nListServiceAccountsResponse.next_page_token."
+                                },
+                                "pageSize":{
+                                    "type":"integer",
+                                    "format":"int32",
+                                    "location":"query",
+                                    "description":"Optional limit on the number of service accounts to include in the\nresponse. Further accounts can subsequently be obtained by including the\nListServiceAccountsResponse.next_page_token\nin a subsequent request."
+                                }
+                            }
+                        },
+                        "get":{
+                            "response":{
+                                "$ref":"ServiceAccount"
+                            },
+                            "flatPath":"v1/projects/{projectsId}/serviceAccounts/{serviceAccountsId}",
+                            "id":"iam.projects.serviceAccounts.get",
+                            "description":"Gets a ServiceAccount.",
+                            "parameterOrder":[
+                                "name"
+                            ],
+                            "path":"v1/{+name}",
+                            "httpMethod":"GET",
+                            "scopes":[
+                                "https://www.googleapis.com/auth/cloud-platform"
+                            ],
+                            "parameters":{
+                                "name":{
+                                    "pattern":"^projects/[^/]+/serviceAccounts/[^/]+$",
+                                    "type":"string",
+                                    "required":true,
+                                    "description":"The resource name of the service account in the following format:\n`projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}`.\nUsing `-` as a wildcard for the `PROJECT_ID` will infer the project from\nthe account. The `ACCOUNT` value can be the `email` address or the\n`unique_id` of the service account.",
+                                    "location":"path"
+                                }
+                            }
+                        },
+                        "delete":{
+                            "response":{
+                                "$ref":"Empty"
+                            },
+                            "flatPath":"v1/projects/{projectsId}/serviceAccounts/{serviceAccountsId}",
+                            "id":"iam.projects.serviceAccounts.delete",
+                            "description":"Deletes a ServiceAccount.",
+                            "parameterOrder":[
+                                "name"
+                            ],
+                            "path":"v1/{+name}",
+                            "httpMethod":"DELETE",
+                            "scopes":[
+                                "https://www.googleapis.com/auth/cloud-platform"
+                            ],
+                            "parameters":{
+                                "name":{
+                                    "pattern":"^projects/[^/]+/serviceAccounts/[^/]+$",
+                                    "type":"string",
+                                    "required":true,
+                                    "description":"The resource name of the service account in the following format:\n`projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}`.\nUsing `-` as a wildcard for the `PROJECT_ID` will infer the project from\nthe account. The `ACCOUNT` value can be the `email` address or the\n`unique_id` of the service account.",
+                                    "location":"path"
+                                }
+                            }
+                        },
+                        "getIamPolicy":{
+                            "response":{
+                                "$ref":"Policy"
+                            },
+                            "flatPath":"v1/projects/{projectsId}/serviceAccounts/{serviceAccountsId}:getIamPolicy",
+                            "id":"iam.projects.serviceAccounts.getIamPolicy",
+                            "description":"Returns the IAM access control policy for a\nServiceAccount.",
+                            "parameterOrder":[
+                                "resource"
+                            ],
+                            "path":"v1/{+resource}:getIamPolicy",
+                            "httpMethod":"POST",
+                            "scopes":[
+                                "https://www.googleapis.com/auth/cloud-platform"
+                            ],
+                            "parameters":{
+                                "resource":{
+                                    "pattern":"^projects/[^/]+/serviceAccounts/[^/]+$",
+                                    "type":"string",
+                                    "required":true,
+                                    "location":"path",
+                                    "description":"REQUIRED: The resource for which the policy is being requested.\nSee the operation documentation for the appropriate value for this field."
+                                }
+                            }
+                        },
+                        "create":{
+                            "response":{
+                                "$ref":"ServiceAccount"
+                            },
+                            "flatPath":"v1/projects/{projectsId}/serviceAccounts",
+                            "id":"iam.projects.serviceAccounts.create",
+                            "description":"Creates a ServiceAccount\nand returns it.",
+                            "parameterOrder":[
+                                "name"
+                            ],
+                            "path":"v1/{+name}/serviceAccounts",
+                            "request":{
+                                "$ref":"CreateServiceAccountRequest"
+                            },
+                            "httpMethod":"POST",
+                            "scopes":[
+                                "https://www.googleapis.com/auth/cloud-platform"
+                            ],
+                            "parameters":{
+                                "name":{
+                                    "pattern":"^projects/[^/]+$",
+                                    "type":"string",
+                                    "required":true,
+                                    "location":"path",
+                                    "description":"Required. The resource name of the project associated with the service\naccounts, such as `projects/my-project-123`."
+                                }
+                            }
+                        },
+                        "update":{
+                            "response":{
+                                "$ref":"ServiceAccount"
+                            },
+                            "flatPath":"v1/projects/{projectsId}/serviceAccounts/{serviceAccountsId}",
+                            "id":"iam.projects.serviceAccounts.update",
+                            "description":"Updates a ServiceAccount.\n\nCurrently, only the following fields are updatable:\n`display_name` .\nThe `etag` is mandatory.",
+                            "request":{
+                                "$ref":"ServiceAccount"
+                            },
+                            "path":"v1/{+name}",
+                            "parameterOrder":[
+                                "name"
+                            ],
+                            "httpMethod":"PUT",
+                            "scopes":[
+                                "https://www.googleapis.com/auth/cloud-platform"
+                            ],
+                            "parameters":{
+                                "name":{
+                                    "pattern":"^projects/[^/]+/serviceAccounts/[^/]+$",
+                                    "type":"string",
+                                    "required":true,
+                                    "location":"path",
+                                    "description":"The resource name of the service account in the following format:\n`projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}`.\n\nRequests using `-` as a wildcard for the `PROJECT_ID` will infer the\nproject from the `account` and the `ACCOUNT` value can be the `email`\naddress or the `unique_id` of the service account.\n\nIn responses the resource name will always be in the format\n`projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}`."
+                                }
+                            }
+                        }
+                    }
+                },
+                "roles":{
+                    "methods":{
+                        "undelete":{
+                            "response":{
+                                "$ref":"Role"
+                            },
+                            "flatPath":"v1/projects/{projectsId}/roles/{rolesId}:undelete",
+                            "id":"iam.projects.roles.undelete",
+                            "description":"Undelete a Role, bringing it back in its previous state.",
+                            "parameterOrder":[
+                                "name"
+                            ],
+                            "path":"v1/{+name}:undelete",
+                            "request":{
+                                "$ref":"UndeleteRoleRequest"
+                            },
+                            "httpMethod":"POST",
+                            "scopes":[
+                                "https://www.googleapis.com/auth/cloud-platform"
+                            ],
+                            "parameters":{
+                                "name":{
+                                    "pattern":"^projects/[^/]+/roles/[^/]+$",
+                                    "type":"string",
+                                    "required":true,
+                                    "location":"path",
+                                    "description":"The resource name of the role in one of the following formats:\n`organizations/{ORGANIZATION_ID}/roles/{ROLE_NAME}`\n`projects/{PROJECT_ID}/roles/{ROLE_NAME}`"
+                                }
+                            }
+                        },
+                        "patch":{
+                            "response":{
+                                "$ref":"Role"
+                            },
+                            "flatPath":"v1/projects/{projectsId}/roles/{rolesId}",
+                            "id":"iam.projects.roles.patch",
+                            "description":"Updates a Role definition.",
+                            "parameterOrder":[
+                                "name"
+                            ],
+                            "path":"v1/{+name}",
+                            "request":{
+                                "$ref":"Role"
+                            },
+                            "httpMethod":"PATCH",
+                            "scopes":[
+                                "https://www.googleapis.com/auth/cloud-platform"
+                            ],
+                            "parameters":{
+                                "name":{
+                                    "pattern":"^projects/[^/]+/roles/[^/]+$",
+                                    "type":"string",
+                                    "required":true,
+                                    "location":"path",
+                                    "description":"The resource name of the role in one of the following formats:\n`roles/{ROLE_NAME}`\n`organizations/{ORGANIZATION_ID}/roles/{ROLE_NAME}`\n`projects/{PROJECT_ID}/roles/{ROLE_NAME}`"
+                                },
+                                "updateMask":{
+                                    "type":"string",
+                                    "format":"google-fieldmask",
+                                    "description":"A mask describing which fields in the Role have changed.",
+                                    "location":"query"
+                                }
+                            }
+                        },
+                        "delete":{
+                            "response":{
+                                "$ref":"Role"
+                            },
+                            "flatPath":"v1/projects/{projectsId}/roles/{rolesId}",
+                            "id":"iam.projects.roles.delete",
+                            "description":"Soft deletes a role. The role is suspended and cannot be used to create new\nIAM Policy Bindings.\nThe Role will not be included in `ListRoles()` unless `show_deleted` is set\nin the `ListRolesRequest`. The Role contains the deleted boolean set.\nExisting Bindings remains, but are inactive. The Role can be undeleted\nwithin 7 days. After 7 days the Role is deleted and all Bindings associated\nwith the role are removed.",
+                            "parameterOrder":[
+                                "name"
+                            ],
+                            "path":"v1/{+name}",
+                            "httpMethod":"DELETE",
+                            "scopes":[
+                                "https://www.googleapis.com/auth/cloud-platform"
+                            ],
+                            "parameters":{
+                                "name":{
+                                    "pattern":"^projects/[^/]+/roles/[^/]+$",
+                                    "type":"string",
+                                    "required":true,
+                                    "description":"The resource name of the role in one of the following formats:\n`organizations/{ORGANIZATION_ID}/roles/{ROLE_NAME}`\n`projects/{PROJECT_ID}/roles/{ROLE_NAME}`",
+                                    "location":"path"
+                                },
+                                "etag":{
+                                    "type":"string",
+                                    "format":"byte",
+                                    "description":"Used to perform a consistent read-modify-write.",
+                                    "location":"query"
+                                }
+                            }
+                        },
+                        "get":{
+                            "response":{
+                                "$ref":"Role"
+                            },
+                            "flatPath":"v1/projects/{projectsId}/roles/{rolesId}",
+                            "id":"iam.projects.roles.get",
+                            "description":"Gets a Role definition.",
+                            "parameterOrder":[
+                                "name"
+                            ],
+                            "path":"v1/{+name}",
+                            "httpMethod":"GET",
+                            "scopes":[
+                                "https://www.googleapis.com/auth/cloud-platform"
+                            ],
+                            "parameters":{
+                                "name":{
+                                    "pattern":"^projects/[^/]+/roles/[^/]+$",
+                                    "type":"string",
+                                    "required":true,
+                                    "description":"The resource name of the role in one of the following formats:\n`roles/{ROLE_NAME}`\n`organizations/{ORGANIZATION_ID}/roles/{ROLE_NAME}`\n`projects/{PROJECT_ID}/roles/{ROLE_NAME}`",
+                                    "location":"path"
+                                }
+                            }
+                        },
+                        "create":{
+                            "response":{
+                                "$ref":"Role"
+                            },
+                            "flatPath":"v1/projects/{projectsId}/roles",
+                            "id":"iam.projects.roles.create",
+                            "description":"Creates a new Role.",
+                            "request":{
+                                "$ref":"CreateRoleRequest"
+                            },
+                            "path":"v1/{+parent}/roles",
+                            "parameterOrder":[
+                                "parent"
+                            ],
+                            "httpMethod":"POST",
+                            "scopes":[
+                                "https://www.googleapis.com/auth/cloud-platform"
+                            ],
+                            "parameters":{
+                                "parent":{
+                                    "pattern":"^projects/[^/]+$",
+                                    "type":"string",
+                                    "required":true,
+                                    "description":"The resource name of the parent resource in one of the following formats:\n`organizations/{ORGANIZATION_ID}`\n`projects/{PROJECT_ID}`",
+                                    "location":"path"
+                                }
+                            }
+                        },
+                        "list":{
+                            "response":{
+                                "$ref":"ListRolesResponse"
+                            },
+                            "flatPath":"v1/projects/{projectsId}/roles",
+                            "id":"iam.projects.roles.list",
+                            "description":"Lists the Roles defined on a resource.",
+                            "parameterOrder":[
+                                "parent"
+                            ],
+                            "path":"v1/{+parent}/roles",
+                            "httpMethod":"GET",
+                            "scopes":[
+                                "https://www.googleapis.com/auth/cloud-platform"
+                            ],
+                            "parameters":{
+                                "pageToken":{
+                                    "type":"string",
+                                    "description":"Optional pagination token returned in an earlier ListRolesResponse.",
+                                    "location":"query"
+                                },
+                                "view":{
+                                    "enum":[
+                                        "BASIC",
+                                        "FULL"
+                                    ],
+                                    "type":"string",
+                                    "location":"query",
+                                    "description":"Optional view for the returned Role objects."
+                                },
+                                "showDeleted":{
+                                    "type":"boolean",
+                                    "description":"Include Roles that have been deleted.",
+                                    "location":"query"
+                                },
+                                "pageSize":{
+                                    "type":"integer",
+                                    "format":"int32",
+                                    "location":"query",
+                                    "description":"Optional limit on the number of roles to include in the response."
+                                },
+                                "parent":{
+                                    "pattern":"^projects/[^/]+$",
+                                    "type":"string",
+                                    "required":true,
+                                    "description":"The resource name of the parent resource in one of the following formats:\n`` (empty string) -- this refers to curated roles.\n`organizations/{ORGANIZATION_ID}`\n`projects/{PROJECT_ID}`",
+                                    "location":"path"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "permissions":{
+            "methods":{
+                "queryTestablePermissions":{
+                    "response":{
+                        "$ref":"QueryTestablePermissionsResponse"
+                    },
+                    "flatPath":"v1/permissions:queryTestablePermissions",
+                    "id":"iam.permissions.queryTestablePermissions",
+                    "description":"Lists the permissions testable on a resource.\nA permission is testable if it can be tested for an identity on a resource.",
+                    "parameterOrder":[],
+                    "path":"v1/permissions:queryTestablePermissions",
+                    "request":{
+                        "$ref":"QueryTestablePermissionsRequest"
+                    },
+                    "httpMethod":"POST",
+                    "scopes":[
+                        "https://www.googleapis.com/auth/cloud-platform"
+                    ],
+                    "parameters":{}
+                }
+            }
+        },
+        "roles":{
+            "methods":{
+                "queryGrantableRoles":{
+                    "response":{
+                        "$ref":"QueryGrantableRolesResponse"
+                    },
+                    "flatPath":"v1/roles:queryGrantableRoles",
+                    "id":"iam.roles.queryGrantableRoles",
+                    "description":"Queries roles that can be granted on a particular resource.\nA role is grantable if it can be used as the role in a binding for a policy\nfor that resource.",
+                    "parameterOrder":[],
+                    "path":"v1/roles:queryGrantableRoles",
+                    "request":{
+                        "$ref":"QueryGrantableRolesRequest"
+                    },
+                    "httpMethod":"POST",
+                    "scopes":[
+                        "https://www.googleapis.com/auth/cloud-platform"
+                    ],
+                    "parameters":{
+                        "bearer_token":{
+                            "type":"string",
+                            "location":"query",
+                            "description":"OAuth bearer token."
+                        },
+                        "callback":{
+                            "type":"string",
+                            "description":"JSONP",
+                            "location":"query"
+                        },
+                        "uploadType":{
+                            "type":"string",
+                            "description":"Legacy upload protocol for media (e.g. \"media\", \"multipart\").",
+                            "location":"query"
+                        },
+                        "prettyPrint":{
+                            "type":"boolean",
+                            "description":"Returns response with indentations and line breaks.",
+                            "location":"query",
+                            "default":"true"
+                        },
+                        "pp":{
+                            "type":"string",
+                            "location":"query"
+                        },
+                        "strict":{
+                            "type":"string",
+                            "location":"query"
+                        },
+                        "trace":{
+                            "type":"string",
+                            "location":"query"
+                        },
+                        "oauth_token":{
+                            "type":"string",
+                            "description":"OAuth 2.0 token for the current user.",
+                            "location":"query"
+                        },
+                        "alt":{
+                            "default":"json",
+                            "description":"Data format for response.",
+                            "enum":[
+                                "json",
+                                "media",
+                                "proto"
+                            ],
+                            "type":"string",
+                            "enumDescriptions":[
+                                "Responses with Content-Type of application/json",
+                                "Media download with context-dependent Content-Type",
+                                "Responses with Content-Type of application/x-protobuf"
+                            ],
+                            "location":"query"
+                        },
+                        "fields":{
+                            "type":"string",
+                            "description":"Selector specifying which fields to include in a partial response.",
+                            "location":"query"
+                        },
+                        "access_token":{
+                            "type":"string",
+                            "location":"query",
+                            "description":"OAuth access token."
+                        },
+                        "quotaUser":{
+                            "type":"string",
+                            "description":"Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.",
+                            "location":"query"
+                        },
+                        "$.xgafv":{
+                            "enum":[
+                                "1",
+                                "2"
+                            ],
+                            "type":"string",
+                            "location":"query",
+                            "enumDescriptions":[
+                                "v1 error format",
+                                "v2 error format"
+                            ],
+                            "description":"V1 error format."
+                        },
+                        "body":{
+                            "type":"object",
+                            "required":true,
+                            "$ref":"QueryGrantableRolesRequest",
+                            "description":"The request body."
+                        },
+                        "upload_protocol":{
+                            "type":"string",
+                            "location":"query",
+                            "description":"Upload protocol for media (e.g. \"raw\", \"multipart\")."
+                        },
+                        "userip":{
+                            "type":"string",
+                            "location":"query"
+                        },
+                        "key":{
+                            "type":"string",
+                            "location":"query",
+                            "description":"API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token."
+                        }
+                    }
+                },
+                "get":{
+                    "response":{
+                        "$ref":"Role"
+                    },
+                    "flatPath":"v1/roles/{rolesId}",
+                    "id":"iam.roles.get",
+                    "description":"Gets a Role definition.",
+                    "parameterOrder":[
+                        "name"
+                    ],
+                    "path":"v1/{+name}",
+                    "httpMethod":"GET",
+                    "scopes":[
+                        "https://www.googleapis.com/auth/cloud-platform"
+                    ],
+                    "parameters":{
+                        "name":{
+                            "pattern":"^roles/[^/]+$",
+                            "type":"string",
+                            "required":true,
+                            "description":"The resource name of the role in one of the following formats:\n`roles/{ROLE_NAME}`\n`organizations/{ORGANIZATION_ID}/roles/{ROLE_NAME}`\n`projects/{PROJECT_ID}/roles/{ROLE_NAME}`",
+                            "location":"path"
+                        },
+                        "bearer_token":{
+                            "type":"string",
+                            "location":"query",
+                            "description":"OAuth bearer token."
+                        },
+                        "uploadType":{
+                            "type":"string",
+                            "description":"Legacy upload protocol for media (e.g. \"media\", \"multipart\").",
+                            "location":"query"
+                        },
+                        "prettyPrint":{
+                            "type":"boolean",
+                            "description":"Returns response with indentations and line breaks.",
+                            "location":"query",
+                            "default":"true"
+                        },
+                        "pp":{
+                            "type":"string",
+                            "location":"query"
+                        },
+                        "strict":{
+                            "type":"string",
+                            "location":"query"
+                        },
+                        "trace":{
+                            "type":"string",
+                            "location":"query"
+                        },
+                        "oauth_token":{
+                            "type":"string",
+                            "description":"OAuth 2.0 token for the current user.",
+                            "location":"query"
+                        },
+                        "alt":{
+                            "default":"json",
+                            "description":"Data format for response.",
+                            "enum":[
+                                "json",
+                                "media",
+                                "proto"
+                            ],
+                            "type":"string",
+                            "enumDescriptions":[
+                                "Responses with Content-Type of application/json",
+                                "Media download with context-dependent Content-Type",
+                                "Responses with Content-Type of application/x-protobuf"
+                            ],
+                            "location":"query"
+                        },
+                        "fields":{
+                            "type":"string",
+                            "description":"Selector specifying which fields to include in a partial response.",
+                            "location":"query"
+                        },
+                        "access_token":{
+                            "type":"string",
+                            "location":"query",
+                            "description":"OAuth access token."
+                        },
+                        "quotaUser":{
+                            "type":"string",
+                            "description":"Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.",
+                            "location":"query"
+                        },
+                        "$.xgafv":{
+                            "enum":[
+                                "1",
+                                "2"
+                            ],
+                            "type":"string",
+                            "location":"query",
+                            "enumDescriptions":[
+                                "v1 error format",
+                                "v2 error format"
+                            ],
+                            "description":"V1 error format."
+                        },
+                        "upload_protocol":{
+                            "type":"string",
+                            "location":"query",
+                            "description":"Upload protocol for media (e.g. \"raw\", \"multipart\")."
+                        },
+                        "callback":{
+                            "type":"string",
+                            "description":"JSONP",
+                            "location":"query"
+                        },
+                        "userip":{
+                            "type":"string",
+                            "location":"query"
+                        },
+                        "key":{
+                            "type":"string",
+                            "location":"query",
+                            "description":"API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token."
+                        }
+                    }
+                },
+                "list":{
+                    "response":{
+                        "$ref":"ListRolesResponse"
+                    },
+                    "flatPath":"v1/roles",
+                    "id":"iam.roles.list",
+                    "description":"Lists the Roles defined on a resource.",
+                    "parameterOrder":[],
+                    "path":"v1/roles",
+                    "httpMethod":"GET",
+                    "scopes":[
+                        "https://www.googleapis.com/auth/cloud-platform"
+                    ],
+                    "parameters":{
+                        "bearer_token":{
+                            "type":"string",
+                            "location":"query",
+                            "description":"OAuth bearer token."
+                        },
+                        "callback":{
+                            "type":"string",
+                            "description":"JSONP",
+                            "location":"query"
+                        },
+                        "showDeleted":{
+                            "type":"boolean",
+                            "description":"Include Roles that have been deleted.",
+                            "location":"query"
+                        },
+                        "trace":{
+                            "type":"string",
+                            "location":"query"
+                        },
+                        "pageSize":{
+                            "type":"integer",
+                            "format":"int32",
+                            "description":"Optional limit on the number of roles to include in the response.",
+                            "location":"query"
+                        },
+                        "prettyPrint":{
+                            "type":"boolean",
+                            "description":"Returns response with indentations and line breaks.",
+                            "location":"query",
+                            "default":"true"
+                        },
+                        "pageToken":{
+                            "type":"string",
+                            "location":"query",
+                            "description":"Optional pagination token returned in an earlier ListRolesResponse."
+                        },
+                        "view":{
+                            "enum":[
+                                "BASIC",
+                                "FULL"
+                            ],
+                            "type":"string",
+                            "description":"Optional view for the returned Role objects.",
+                            "location":"query"
+                        },
+                        "pp":{
+                            "type":"string",
+                            "location":"query"
+                        },
+                        "uploadType":{
+                            "type":"string",
+                            "description":"Legacy upload protocol for media (e.g. \"media\", \"multipart\").",
+                            "location":"query"
+                        },
+                        "oauth_token":{
+                            "type":"string",
+                            "description":"OAuth 2.0 token for the current user.",
+                            "location":"query"
+                        },
+                        "parent":{
+                            "type":"string",
+                            "description":"The resource name of the parent resource in one of the following formats:\n`` (empty string) -- this refers to curated roles.\n`organizations/{ORGANIZATION_ID}`\n`projects/{PROJECT_ID}`",
+                            "location":"query"
+                        },
+                        "fields":{
+                            "type":"string",
+                            "description":"Selector specifying which fields to include in a partial response.",
+                            "location":"query"
+                        },
+                        "strict":{
+                            "type":"string",
+                            "location":"query"
+                        },
+                        "access_token":{
+                            "type":"string",
+                            "location":"query",
+                            "description":"OAuth access token."
+                        },
+                        "quotaUser":{
+                            "type":"string",
+                            "description":"Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.",
+                            "location":"query"
+                        },
+                        "$.xgafv":{
+                            "enum":[
+                                "1",
+                                "2"
+                            ],
+                            "type":"string",
+                            "location":"query",
+                            "enumDescriptions":[
+                                "v1 error format",
+                                "v2 error format"
+                            ],
+                            "description":"V1 error format."
+                        },
+                        "alt":{
+                            "default":"json",
+                            "description":"Data format for response.",
+                            "enum":[
+                                "json",
+                                "media",
+                                "proto"
+                            ],
+                            "type":"string",
+                            "enumDescriptions":[
+                                "Responses with Content-Type of application/json",
+                                "Media download with context-dependent Content-Type",
+                                "Responses with Content-Type of application/x-protobuf"
+                            ],
+                            "location":"query"
+                        },
+                        "upload_protocol":{
+                            "type":"string",
+                            "location":"query",
+                            "description":"Upload protocol for media (e.g. \"raw\", \"multipart\")."
+                        },
+                        "userip":{
+                            "type":"string",
+                            "location":"query"
+                        },
+                        "key":{
+                            "type":"string",
+                            "location":"query",
+                            "description":"API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token."
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "fullyEncodeReservedExpansion":true,
+    "schemas":{
+        "Role":{
+            "properties":{
+                "name":{
+                    "type":"string",
+                    "description":"The name of the role.\n\nWhen Role is used in CreateRole, the role name must not be set.\n\nWhen Role is used in output and other input such as UpdateRole, the role\nname is the complete path, e.g., roles/logging.viewer for curated roles\nand organizations/{ORGANIZATION_ID}/roles/logging.viewer for custom roles."
+                },
+                "etag":{
+                    "type":"string",
+                    "format":"byte",
+                    "description":"Used to perform a consistent read-modify-write."
+                },
+                "description":{
+                    "type":"string",
+                    "description":"Optional.  A human-readable description for the role."
+                },
+                "title":{
+                    "type":"string",
+                    "description":"Optional.  A human-readable title for the role.  Typically this\nis limited to 100 UTF-8 bytes."
+                },
+                "includedPermissions":{
+                    "type":"array",
+                    "items":{
+                        "type":"string"
+                    },
+                    "description":"The names of the permissions this role grants when bound in an IAM policy."
+                },
+                "stage":{
+                    "enum":[
+                        "ALPHA",
+                        "BETA",
+                        "GA",
+                        "DEPRECATED",
+                        "DISABLED",
+                        "EAP"
+                    ],
+                    "type":"string",
+                    "enumDescriptions":[
+                        "The user has indicated this role is currently in an alpha phase.",
+                        "The user has indicated this role is currently in a beta phase.",
+                        "The user has indicated this role is generally available.",
+                        "The user has indicated this role is being deprecated.",
+                        "This role is disabled and will not contribute permissions to any members\nit is granted to in policies.",
+                        "The user has indicated this role is currently in an eap phase."
+                    ],
+                    "description":"The current launch stage of the role."
+                },
+                "deleted":{
+                    "type":"boolean",
+                    "description":"The current deleted state of the role. This field is read only.\nIt will be ignored in calls to CreateRole and UpdateRole."
+                }
+            },
+            "type":"object",
+            "id":"Role",
+            "description":"A role in the Identity and Access Management API."
+        },
+        "SignJwtResponse":{
+            "properties":{
+                "keyId":{
+                    "type":"string",
+                    "description":"The id of the key used to sign the JWT."
+                },
+                "signedJwt":{
+                    "type":"string",
+                    "description":"The signed JWT."
+                }
+            },
+            "type":"object",
+            "id":"SignJwtResponse",
+            "description":"The service account sign JWT response."
+        },
+        "BindingDelta":{
+            "properties":{
+                "role":{
+                    "type":"string",
+                    "description":"Role that is assigned to `members`.\nFor example, `roles/viewer`, `roles/editor`, or `roles/owner`.\nRequired"
+                },
+                "action":{
+                    "enum":[
+                        "ACTION_UNSPECIFIED",
+                        "ADD",
+                        "REMOVE"
+                    ],
+                    "type":"string",
+                    "enumDescriptions":[
+                        "Unspecified.",
+                        "Addition of a Binding.",
+                        "Removal of a Binding."
+                    ],
+                    "description":"The action that was performed on a Binding.\nRequired"
+                },
+                "member":{
+                    "type":"string",
+                    "description":"A single identity requesting access for a Cloud Platform resource.\nFollows the same format of Binding.members.\nRequired"
+                }
+            },
+            "type":"object",
+            "id":"BindingDelta",
+            "description":"One delta entry for Binding. Each individual change (only one member in each\nentry) to a binding will be a separate entry."
+        },
+        "QueryGrantableRolesResponse":{
+            "properties":{
+                "nextPageToken":{
+                    "type":"string",
+                    "description":"To retrieve the next page of results, set\n`QueryGrantableRolesRequest.page_token` to this value."
+                },
+                "roles":{
+                    "type":"array",
+                    "items":{
+                        "$ref":"Role"
+                    },
+                    "description":"The list of matching roles."
+                }
+            },
+            "type":"object",
+            "id":"QueryGrantableRolesResponse",
+            "description":"The grantable role query response."
+        },
+        "SignBlobRequest":{
+            "properties":{
+                "bytesToSign":{
+                    "type":"string",
+                    "format":"byte",
+                    "description":"The bytes to sign."
+                }
+            },
+            "type":"object",
+            "id":"SignBlobRequest",
+            "description":"The service account sign blob request."
+        },
+        "TestIamPermissionsRequest":{
+            "properties":{
+                "permissions":{
+                    "type":"array",
+                    "items":{
+                        "type":"string"
+                    },
+                    "description":"The set of permissions to check for the `resource`. Permissions with\nwildcards (such as '*' or 'storage.*') are not allowed. For more\ninformation see\n[IAM Overview](https://cloud.google.com/iam/docs/overview#permissions)."
+                }
+            },
+            "type":"object",
+            "id":"TestIamPermissionsRequest",
+            "description":"Request message for `TestIamPermissions` method."
+        },
+        "QueryTestablePermissionsRequest":{
+            "properties":{
+                "pageToken":{
+                    "type":"string",
+                    "description":"Optional pagination token returned in an earlier\nQueryTestablePermissionsRequest."
+                },
+                "fullResourceName":{
+                    "type":"string",
+                    "description":"Required. The full resource name to query from the list of testable\npermissions.\n\nThe name follows the Google Cloud Platform resource format.\nFor example, a Cloud Platform project with id `my-project` will be named\n`//cloudresourcemanager.googleapis.com/projects/my-project`."
+                },
+                "pageSize":{
+                    "type":"integer",
+                    "format":"int32",
+                    "description":"Optional limit on the number of permissions to include in the response."
+                }
+            },
+            "type":"object",
+            "id":"QueryTestablePermissionsRequest",
+            "description":"A request to get permissions which can be tested on a resource."
+        },
+        "ListServiceAccountsResponse":{
+            "properties":{
+                "accounts":{
+                    "type":"array",
+                    "items":{
+                        "$ref":"ServiceAccount"
+                    },
+                    "description":"The list of matching service accounts."
+                },
+                "nextPageToken":{
+                    "type":"string",
+                    "description":"To retrieve the next page of results, set\nListServiceAccountsRequest.page_token\nto this value."
+                }
+            },
+            "type":"object",
+            "id":"ListServiceAccountsResponse",
+            "description":"The service account list response."
+        },
+        "QueryTestablePermissionsResponse":{
+            "properties":{
+                "permissions":{
+                    "type":"array",
+                    "items":{
+                        "$ref":"Permission"
+                    },
+                    "description":"The Permissions testable on the requested resource."
+                },
+                "nextPageToken":{
+                    "type":"string",
+                    "description":"To retrieve the next page of results, set\n`QueryTestableRolesRequest.page_token` to this value."
+                }
+            },
+            "type":"object",
+            "id":"QueryTestablePermissionsResponse",
+            "description":"The response containing permissions which can be tested on a resource."
+        },
+        "CreateRoleRequest":{
+            "properties":{
+                "roleId":{
+                    "type":"string",
+                    "description":"The role id to use for this role."
+                },
+                "role":{
+                    "$ref":"Role",
+                    "description":"The Role resource to create."
+                }
+            },
+            "type":"object",
+            "id":"CreateRoleRequest",
+            "description":"The request to create a new role."
+        },
+        "QueryGrantableRolesRequest":{
+            "properties":{
+                "pageToken":{
+                    "type":"string",
+                    "description":"Optional pagination token returned in an earlier\nQueryGrantableRolesResponse."
+                },
+                "fullResourceName":{
+                    "type":"string",
+                    "description":"Required. The full resource name to query from the list of grantable roles.\n\nThe name follows the Google Cloud Platform resource format.\nFor example, a Cloud Platform project with id `my-project` will be named\n`//cloudresourcemanager.googleapis.com/projects/my-project`."
+                },
+                "pageSize":{
+                    "type":"integer",
+                    "format":"int32",
+                    "description":"Optional limit on the number of roles to include in the response."
+                },
+                "view":{
+                    "enum":[
+                        "BASIC",
+                        "FULL"
+                    ],
+                    "type":"string",
+                    "enumDescriptions":[
+                        "Omits the `included_permissions` field.\nThis is the default value.",
+                        "Returns all fields."
+                    ]
+                }
+            },
+            "type":"object",
+            "id":"QueryGrantableRolesRequest",
+            "description":"The grantable role query request."
+        },
+        "SetIamPolicyRequest":{
+            "properties":{
+                "policy":{
+                    "$ref":"Policy",
+                    "description":"REQUIRED: The complete policy to be applied to the `resource`. The size of\nthe policy is limited to a few 10s of KB. An empty policy is a\nvalid policy but certain Cloud Platform services (such as Projects)\nmight reject them."
+                }
+            },
+            "type":"object",
+            "id":"SetIamPolicyRequest",
+            "description":"Request message for `SetIamPolicy` method."
+        },
+        "AuditData":{
+            "properties":{
+                "policyDelta":{
+                    "$ref":"PolicyDelta",
+                    "description":"Policy delta between the original policy and the newly set policy."
+                }
+            },
+            "type":"object",
+            "id":"AuditData",
+            "description":"Audit log information specific to Cloud IAM. This message is serialized\nas an `Any` type in the `ServiceData` message of an\n`AuditLog` message."
+        },
+        "Policy":{
+            "properties":{
+                "etag":{
+                    "type":"string",
+                    "format":"byte",
+                    "description":"`etag` is used for optimistic concurrency control as a way to help\nprevent simultaneous updates of a policy from overwriting each other.\nIt is strongly suggested that systems make use of the `etag` in the\nread-modify-write cycle to perform policy updates in order to avoid race\nconditions: An `etag` is returned in the response to `getIamPolicy`, and\nsystems are expected to put that etag in the request to `setIamPolicy` to\nensure that their change will be applied to the same version of the policy.\n\nIf no `etag` is provided in the call to `setIamPolicy`, then the existing\npolicy is overwritten blindly."
+                },
+                "bindings":{
+                    "type":"array",
+                    "items":{
+                        "$ref":"Binding"
+                    },
+                    "description":"Associates a list of `members` to a `role`.\n`bindings` with no members will result in an error."
+                },
+                "version":{
+                    "type":"integer",
+                    "format":"int32",
+                    "description":"Deprecated."
+                }
+            },
+            "type":"object",
+            "id":"Policy",
+            "description":"Defines an Identity and Access Management (IAM) policy. It is used to\nspecify access control policies for Cloud Platform resources.\n\n\nA `Policy` consists of a list of `bindings`. A `Binding` binds a list of\n`members` to a `role`, where the members can be user accounts, Google groups,\nGoogle domains, and service accounts. A `role` is a named list of permissions\ndefined by IAM.\n\n**Example**\n\n    {\n      \"bindings\": [\n        {\n          \"role\": \"roles/owner\",\n          \"members\": [\n            \"user:mike@example.com\",\n            \"group:admins@example.com\",\n            \"domain:google.com\",\n            \"serviceAccount:my-other-app@appspot.gserviceaccount.com\",\n          ]\n        },\n        {\n          \"role\": \"roles/viewer\",\n          \"members\": [\"user:sean@example.com\"]\n        }\n      ]\n    }\n\nFor a description of IAM and its features, see the\n[IAM developer's guide](https://cloud.google.com/iam/docs)."
+        },
+        "SignJwtRequest":{
+            "properties":{
+                "payload":{
+                    "type":"string",
+                    "description":"The JWT payload to sign, a JSON JWT Claim set."
+                }
+            },
+            "type":"object",
+            "id":"SignJwtRequest",
+            "description":"The service account sign JWT request."
+        },
+        "CreateServiceAccountRequest":{
+            "properties":{
+                "serviceAccount":{
+                    "$ref":"ServiceAccount",
+                    "description":"The ServiceAccount resource to create.\nCurrently, only the following values are user assignable:\n`display_name` ."
+                },
+                "accountId":{
+                    "type":"string",
+                    "description":"Required. The account id that is used to generate the service account\nemail address and a stable unique id. It is unique within a project,\nmust be 6-30 characters long, and match the regular expression\n`[a-z]([-a-z0-9]*[a-z0-9])` to comply with RFC1035."
+                }
+            },
+            "type":"object",
+            "id":"CreateServiceAccountRequest",
+            "description":"The service account create request."
+        },
+        "Binding":{
+            "properties":{
+                "role":{
+                    "type":"string",
+                    "description":"Role that is assigned to `members`.\nFor example, `roles/viewer`, `roles/editor`, or `roles/owner`.\nRequired"
+                },
+                "members":{
+                    "type":"array",
+                    "items":{
+                        "type":"string"
+                    },
+                    "description":"Specifies the identities requesting access for a Cloud Platform resource.\n`members` can have the following values:\n\n* `allUsers`: A special identifier that represents anyone who is\n   on the internet; with or without a Google account.\n\n* `allAuthenticatedUsers`: A special identifier that represents anyone\n   who is authenticated with a Google account or a service account.\n\n* `user:{emailid}`: An email address that represents a specific Google\n   account. For example, `alice@gmail.com` or `joe@example.com`.\n\n\n* `serviceAccount:{emailid}`: An email address that represents a service\n   account. For example, `my-other-app@appspot.gserviceaccount.com`.\n\n* `group:{emailid}`: An email address that represents a Google group.\n   For example, `admins@example.com`.\n\n\n* `domain:{domain}`: A Google Apps domain name that represents all the\n   users of that domain. For example, `google.com` or `example.com`.\n\n"
+                }
+            },
+            "type":"object",
+            "id":"Binding",
+            "description":"Associates `members` with a `role`."
+        },
+        "SignBlobResponse":{
+            "properties":{
+                "keyId":{
+                    "type":"string",
+                    "description":"The id of the key used to sign the blob."
+                },
+                "signature":{
+                    "type":"string",
+                    "format":"byte",
+                    "description":"The signed blob."
+                }
+            },
+            "type":"object",
+            "id":"SignBlobResponse",
+            "description":"The service account sign blob response."
+        },
+        "TestIamPermissionsResponse":{
+            "properties":{
+                "permissions":{
+                    "type":"array",
+                    "items":{
+                        "type":"string"
+                    },
+                    "description":"A subset of `TestPermissionsRequest.permissions` that the caller is\nallowed."
+                }
+            },
+            "type":"object",
+            "id":"TestIamPermissionsResponse",
+            "description":"Response message for `TestIamPermissions` method."
+        },
+        "UndeleteRoleRequest":{
+            "properties":{
+                "etag":{
+                    "type":"string",
+                    "format":"byte",
+                    "description":"Used to perform a consistent read-modify-write."
+                }
+            },
+            "type":"object",
+            "id":"UndeleteRoleRequest",
+            "description":"The request to undelete an existing role."
+        },
+        "CreateServiceAccountKeyRequest":{
+            "properties":{
+                "privateKeyType":{
+                    "enum":[
+                        "TYPE_UNSPECIFIED",
+                        "TYPE_PKCS12_FILE",
+                        "TYPE_GOOGLE_CREDENTIALS_FILE"
+                    ],
+                    "type":"string",
+                    "enumDescriptions":[
+                        "Unspecified. Equivalent to `TYPE_GOOGLE_CREDENTIALS_FILE`.",
+                        "PKCS12 format.\nThe password for the PKCS12 file is `notasecret`.\nFor more information, see https://tools.ietf.org/html/rfc7292.",
+                        "Google Credentials File format."
+                    ],
+                    "description":"The output format of the private key. `GOOGLE_CREDENTIALS_FILE` is the\ndefault output format."
+                },
+                "keyAlgorithm":{
+                    "enum":[
+                        "KEY_ALG_UNSPECIFIED",
+                        "KEY_ALG_RSA_1024",
+                        "KEY_ALG_RSA_2048"
+                    ],
+                    "type":"string",
+                    "enumDescriptions":[
+                        "An unspecified key algorithm.",
+                        "1k RSA Key.",
+                        "2k RSA Key."
+                    ],
+                    "description":"Which type of key and algorithm to use for the key.\nThe default is currently a 2K RSA key.  However this may change in the\nfuture."
+                }
+            },
+            "type":"object",
+            "id":"CreateServiceAccountKeyRequest",
+            "description":"The service account key create request."
+        },
+        "Empty":{
+            "properties":{},
+            "type":"object",
+            "id":"Empty",
+            "description":"A generic empty message that you can re-use to avoid defining duplicated\nempty messages in your APIs. A typical example is to use it as the request\nor the response type of an API method. For instance:\n\n    service Foo {\n      rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);\n    }\n\nThe JSON representation for `Empty` is empty JSON object `{}`."
+        },
+        "PolicyDelta":{
+            "properties":{
+                "bindingDeltas":{
+                    "type":"array",
+                    "items":{
+                        "$ref":"BindingDelta"
+                    },
+                    "description":"The delta for Bindings between two policies."
+                }
+            },
+            "type":"object",
+            "id":"PolicyDelta",
+            "description":"The difference delta between two policies."
+        },
+        "ListServiceAccountKeysResponse":{
+            "properties":{
+                "keys":{
+                    "type":"array",
+                    "items":{
+                        "$ref":"ServiceAccountKey"
+                    },
+                    "description":"The public keys for the service account."
+                }
+            },
+            "type":"object",
+            "id":"ListServiceAccountKeysResponse",
+            "description":"The service account keys list response."
+        },
+        "ListRolesResponse":{
+            "properties":{
+                "nextPageToken":{
+                    "type":"string",
+                    "description":"To retrieve the next page of results, set\n`ListRolesRequest.page_token` to this value."
+                },
+                "roles":{
+                    "type":"array",
+                    "items":{
+                        "$ref":"Role"
+                    },
+                    "description":"The Roles defined on this resource."
+                }
+            },
+            "type":"object",
+            "id":"ListRolesResponse",
+            "description":"The response containing the roles defined under a resource."
+        },
+        "Permission":{
+            "properties":{
+                "name":{
+                    "type":"string",
+                    "description":"The name of this Permission."
+                },
+                "description":{
+                    "type":"string",
+                    "description":"A brief description of what this Permission is used for."
+                },
+                "title":{
+                    "type":"string",
+                    "description":"The title of this Permission."
+                },
+                "customRolesSupportLevel":{
+                    "enum":[
+                        "SUPPORTED",
+                        "TESTING",
+                        "NOT_SUPPORTED"
+                    ],
+                    "type":"string",
+                    "enumDescriptions":[
+                        "Permission is fully supported for custom role use.",
+                        "Permission is being tested to check custom role compatibility.",
+                        "Permission is not supported for custom role use."
+                    ],
+                    "description":"The current custom role support level."
+                },
+                "stage":{
+                    "enum":[
+                        "ALPHA",
+                        "BETA",
+                        "GA",
+                        "DEPRECATED"
+                    ],
+                    "type":"string",
+                    "enumDescriptions":[
+                        "The permission is currently in an alpha phase.",
+                        "The permission is currently in a beta phase.",
+                        "The permission is generally available.",
+                        "The permission is being deprecated."
+                    ],
+                    "description":"The current launch stage of the permission."
+                },
+                "onlyInPredefinedRoles":{
+                    "type":"boolean",
+                    "description":"This permission can ONLY be used in predefined roles."
+                }
+            },
+            "type":"object",
+            "id":"Permission",
+            "description":"A permission which can be included by a role."
+        },
+        "ServiceAccount":{
+            "properties":{
+                "uniqueId":{
+                    "type":"string",
+                    "description":"@OutputOnly The unique and stable id of the service account."
+                },
+                "name":{
+                    "type":"string",
+                    "description":"The resource name of the service account in the following format:\n`projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}`.\n\nRequests using `-` as a wildcard for the `PROJECT_ID` will infer the\nproject from the `account` and the `ACCOUNT` value can be the `email`\naddress or the `unique_id` of the service account.\n\nIn responses the resource name will always be in the format\n`projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}`."
+                },
+                "etag":{
+                    "type":"string",
+                    "format":"byte",
+                    "description":"Used to perform a consistent read-modify-write."
+                },
+                "projectId":{
+                    "type":"string",
+                    "description":"@OutputOnly The id of the project that owns the service account."
+                },
+                "displayName":{
+                    "type":"string",
+                    "description":"Optional. A user-specified description of the service account.  Must be\nfewer than 100 UTF-8 bytes."
+                },
+                "oauth2ClientId":{
+                    "type":"string",
+                    "description":"@OutputOnly The OAuth2 client id for the service account.\nThis is used in conjunction with the OAuth2 clientconfig API to make\nthree legged OAuth2 (3LO) flows to access the data of Google users."
+                },
+                "email":{
+                    "type":"string",
+                    "description":"@OutputOnly The email address of the service account."
+                }
+            },
+            "type":"object",
+            "id":"ServiceAccount",
+            "description":"A service account in the Identity and Access Management API.\n\nTo create a service account, specify the `project_id` and the `account_id`\nfor the account.  The `account_id` is unique within the project, and is used\nto generate the service account email address and a stable\n`unique_id`.\n\nIf the account already exists, the account's resource name is returned\nin the format of projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}. The caller\ncan use the name in other methods to access the account.\n\nAll other methods can identify the service account using the format\n`projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}`.\nUsing `-` as a wildcard for the `PROJECT_ID` will infer the project from\nthe account. The `ACCOUNT` value can be the `email` address or the\n`unique_id` of the service account."
+        },
+        "ServiceAccountKey":{
+            "properties":{
+                "name":{
+                    "type":"string",
+                    "description":"The resource name of the service account key in the following format\n`projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}/keys/{key}`."
+                },
+                "privateKeyData":{
+                    "type":"string",
+                    "format":"byte",
+                    "description":"The private key data. Only provided in `CreateServiceAccountKey`\nresponses. Make sure to keep the private key data secure because it\nallows for the assertion of the service account identity.\nWhen decoded, the private key data can be used to authenticate with\nGoogle API client libraries and with\n<a href=\"/sdk/gcloud/reference/auth/activate-service-account\">gcloud\nauth activate-service-account</a>."
+                },
+                "validBeforeTime":{
+                    "type":"string",
+                    "format":"google-datetime",
+                    "description":"The key can be used before this timestamp."
+                },
+                "publicKeyData":{
+                    "type":"string",
+                    "format":"byte",
+                    "description":"The public key data. Only provided in `GetServiceAccountKey` responses."
+                },
+                "validAfterTime":{
+                    "type":"string",
+                    "format":"google-datetime",
+                    "description":"The key can be used after this timestamp."
+                },
+                "keyAlgorithm":{
+                    "enum":[
+                        "KEY_ALG_UNSPECIFIED",
+                        "KEY_ALG_RSA_1024",
+                        "KEY_ALG_RSA_2048"
+                    ],
+                    "type":"string",
+                    "enumDescriptions":[
+                        "An unspecified key algorithm.",
+                        "1k RSA Key.",
+                        "2k RSA Key."
+                    ],
+                    "description":"Specifies the algorithm (and possibly key size) for the key."
+                },
+                "privateKeyType":{
+                    "enum":[
+                        "TYPE_UNSPECIFIED",
+                        "TYPE_PKCS12_FILE",
+                        "TYPE_GOOGLE_CREDENTIALS_FILE"
+                    ],
+                    "type":"string",
+                    "enumDescriptions":[
+                        "Unspecified. Equivalent to `TYPE_GOOGLE_CREDENTIALS_FILE`.",
+                        "PKCS12 format.\nThe password for the PKCS12 file is `notasecret`.\nFor more information, see https://tools.ietf.org/html/rfc7292.",
+                        "Google Credentials File format."
+                    ],
+                    "description":"The output format for the private key.\nOnly provided in `CreateServiceAccountKey` responses, not\nin `GetServiceAccountKey` or `ListServiceAccountKey` responses.\n\nGoogle never exposes system-managed private keys, and never retains\nuser-managed private keys."
+                }
+            },
+            "type":"object",
+            "id":"ServiceAccountKey",
+            "description":"Represents a service account key.\n\nA service account has two sets of key-pairs: user-managed, and\nsystem-managed.\n\nUser-managed key-pairs can be created and deleted by users.  Users are\nresponsible for rotating these keys periodically to ensure security of\ntheir service accounts.  Users retain the private key of these key-pairs,\nand Google retains ONLY the public key.\n\nSystem-managed key-pairs are managed automatically by Google, and rotated\ndaily without user intervention.  The private key never leaves Google's\nservers to maximize security.\n\nPublic keys for all service accounts are also published at the OAuth2\nService Account API."
+        }
+    },
+    "title":"Google Identity and Access Management (IAM) API",
+    "ownerName":"Google",
+    "servicePath":"",
+    "version_module":true,
+    "version":"v1",
+    "description":"Manages identity and access control for Google Cloud Platform resources, including the creation of service accounts, which you can use to authenticate to Google and make API calls.",
+    "batchPath":"batch"
+}

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -48,11 +48,13 @@ from googleapiclient.discovery import _fix_up_method_description
 from googleapiclient.discovery import _fix_up_parameters
 from googleapiclient.discovery import _urljoin
 from googleapiclient.discovery import build
+from googleapiclient.discovery import build_subresource
 from googleapiclient.discovery import build_from_document
 from googleapiclient.discovery import DISCOVERY_URI
 from googleapiclient.discovery import key2param
 from googleapiclient.discovery import MEDIA_BODY_PARAMETER_DEFAULT_VALUE
 from googleapiclient.discovery import MEDIA_MIME_TYPE_PARAMETER_DEFAULT_VALUE
+from googleapiclient.discovery import Resource
 from googleapiclient.discovery import ResourceMethodParameters
 from googleapiclient.discovery import STACK_QUERY_PARAMETERS
 from googleapiclient.discovery import STACK_QUERY_PARAMETER_DEFAULT_VALUE
@@ -1479,6 +1481,26 @@ class Next(unittest.TestCase):
     parsed = list(urlparse(next_request.uri))
     q = parse_qs(parsed[4])
     self.assertEqual(q['pageToken'][0], '123abc')
+
+
+class DiscoverySubresources(unittest.TestCase):
+
+  def test_build_valid_subresources(self):
+    self.http = HttpMock(datafile('iam.json'), {'status': '200'})
+
+    client = build_subresource('iam.roles', 'v1', http=self.http)
+    self.assertTrue(client)
+    self.assertIsInstance(client, Resource)
+
+    client = build_subresource('iam.projects.roles', 'v1', http=self.http)
+    self.assertTrue(client)
+    self.assertIsInstance(client, Resource)
+
+  def test_build_nonexistent_subresource(self):
+    self.http = HttpMock(datafile('iam.json'), {'status': '200'})
+
+    with self.assertRaises(AttributeError):
+      build_subresource('iam.bogus_subresource', 'v1', http=self.http)
 
 
 class MediaGet(unittest.TestCase):


### PR DESCRIPTION
One of our apps needs to use googleapiclient to hit the GCP APIs for multiple projects, using different credentials.  This gets pretty repetitive with all of the subresources that the GCP APIs have:

```python
iam_a = build('iam', 'v1', credentials=proj_a)
iam_roles_a = iam_a.roles()
iam_b = build('iam', 'v1', credentials=proj_b)
iam_roles_b = iam_b.roles()

crm_a = build('cloudresourcemanager', 'v1beta1', credentials=proj_a)
crm_keys = crm_a.projects().serviceAccounts().keys()
```

After refactoring a bit, `googleapiclient.discovery` seems like the best place for this functionality.  With the change in this branch, the above becomes:
```
iam_roles_a = build_subresource('iam.roles', 'v1', credentials=proj_a)
iam_roles_b = build_subresource('iam.roles', 'v1', credentials=proj_b)
crm_a = build_subresource('cloudresourcemanager.projects.serviceAccounts.keys', 'v1beta1', credentials=proj_a)
```

Would you consider merging?