### PR TITLE
http.py _retry_request improve exponential backoff

### DIFF
--- a/googleapiclient/http.py
+++ b/googleapiclient/http.py
@@ -154,7 +154,7 @@ def _retry_request(http, num_retries, req_type, sleep, rand, uri, method, *args,
   for retry_num in range(num_retries + 1):
     if retry_num > 0:
       # Sleep before retrying.
-      sleep_time = rand() * 2 ** retry_num
+      sleep_time = (1 + rand()) * 2 ** (retry_num - 1)
       LOGGER.warning(
           'Sleeping %.2f seconds before retry %d of %d for %s: %s %s, after %s',
           sleep_time, retry_num, num_retries, req_type, method, uri,


### PR DESCRIPTION
When I use `num_retries=5` I may see in the logs:
```
Sleeping 0.04 seconds before retry 1 of 5 for request ...
Sleeping 2.59 seconds before retry 2 of 5 for request ...
Sleeping 0.74 seconds before retry 3 of 5 for request ...
Sleeping 0.36 seconds before retry 4 of 5 for request ...
Sleeping 0.62 seconds before retry 5 of 5 for request ...
```
Which is in total approx 5sec, but I would expect something between 16-32sec total. Also, see the Google backoff rule https://cloud.google.com/storage/docs/exponential-backoff

My change does not follow the doc, but at least is closer to that is than the current documentation.
