### PR TITLE
Increase the default media chunksize to 100MB.

### DIFF
--- a/googleapiclient/http.py
+++ b/googleapiclient/http.py
@@ -74,7 +74,7 @@ from googleapiclient.model import JsonModel
 
 LOGGER = logging.getLogger(__name__)
 
-DEFAULT_CHUNK_SIZE = 512*1024
+DEFAULT_CHUNK_SIZE = 100*1024*1024
 
 MAX_URI_LENGTH = 2048
 


### PR DESCRIPTION
The current `DEFAULT_CHUNK_SIZE` of 512kb leads to unnecessarily slow
transfers, as in googlecolab/backend-container#1. Increasing this simply
lowers the overhead for large transfers.

Fixes #481.

PTAL @jonparrott -- I couldn't think of a meaningful test that didn't involve basically repeating the constant in another file, which feels silly. :grinning: 