### PR TITLE
discovery.py: remove unused oauth2client import

### DIFF
--- a/googleapiclient/discovery.py
+++ b/googleapiclient/discovery.py
@@ -72,7 +72,6 @@ from googleapiclient.model import JsonModel
 from googleapiclient.model import MediaModel
 from googleapiclient.model import RawModel
 from googleapiclient.schema import Schemas
-from oauth2client.client import GoogleCredentials
 
 # Oauth2client < 3 has the positional helper in 'util', >= 3 has it
 # in '_helpers'.


### PR DESCRIPTION
Remove unused GoogleCredentials import from oauth2client
Decrease dependency from oauth2client, discovery should be able to work
without oauth2client installed