### PR TITLE
Remove check for a failed googleapiclient upgrade

### DIFF
--- a/apiclient/__init__.py
+++ b/apiclient/__init__.py
@@ -4,17 +4,6 @@ from six import iteritems
 
 import googleapiclient
 
-try:
-  import oauth2client
-except ImportError:
-  raise RuntimeError(
-      'Previous version of google-api-python-client detected; due to a '
-      'packaging issue, we cannot perform an in-place upgrade. To repair, '
-      'remove and reinstall this package, along with oauth2client and '
-      'uritemplate. One can do this with pip via\n'
-      '  pip install -I google-api-python-client'
-  )
-
 from googleapiclient import channel
 from googleapiclient import discovery
 from googleapiclient import errors


### PR DESCRIPTION
oauth2client is not even a required dependency now, so this check throws a confusing error message

This sort of fixes #521, but I still can't import `apiclient.discovery` without having `oauth2client` installed:

```
>>> from apiclient import discovery
Traceback (most recent call last):
  File "/Users/epall/projects/google-api-python-client/googleapiclient/sample_tools.py", line 32, in <module>
    from oauth2client import client
ModuleNotFoundError: No module named 'oauth2client'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/epall/projects/google-api-python-client/apiclient/__init__.py", line 13, in <module>
    from googleapiclient import sample_tools
  File "/Users/epall/projects/google-api-python-client/googleapiclient/sample_tools.py", line 36, in <module>
    raise ImportError('googleapiclient.sample_tools requires oauth2client. Please install oauth2client and try again.')
ImportError: googleapiclient.sample_tools requires oauth2client. Please install oauth2client and try again.
>>>
```