### PR TITLE
Make apiclient.sample_tools optional

### DIFF
--- a/apiclient/__init__.py
+++ b/apiclient/__init__.py
@@ -10,7 +10,12 @@ from googleapiclient import errors
 from googleapiclient import http
 from googleapiclient import mimeparse
 from googleapiclient import model
-from googleapiclient import sample_tools
+try:
+    from googleapiclient import sample_tools
+except ImportError:
+    # Silently ignore, because the vast majority of consumers won't use it and
+    # it has deep dependence on oauth2client, an optional dependency.
+    sample_tools = None
 from googleapiclient import schema
 
 __version__ = googleapiclient.__version__


### PR DESCRIPTION
It depends heavily on oauth2client, which has been dropped as a required dependency

This seems to me like the quickest way to tackle #524, but it feels ugly. Maybe `sample_tools` needs to get re-written to use `google-auth`?