### PR TITLE
Make oauth2client even more optional.

### DIFF
--- a/googleapiclient/sample_tools.py
+++ b/googleapiclient/sample_tools.py
@@ -28,14 +28,6 @@ import os
 from googleapiclient import discovery
 from googleapiclient.http import build_http
 
-try:
-    from oauth2client import client
-    from oauth2client import file
-    from oauth2client import tools
-except ImportError:
-    raise ImportError('googleapiclient.sample_tools requires oauth2client. Please install oauth2client and try again.')
-
-
 def init(argv, name, version, doc, filename, scope=None, parents=[], discovery_filename=None):
   """A common initialization routine for samples.
 
@@ -60,6 +52,13 @@ def init(argv, name, version, doc, filename, scope=None, parents=[], discovery_f
     A tuple of (service, flags), where service is the service object and flags
     is the parsed command-line flags.
   """
+  try:
+      from oauth2client import client
+      from oauth2client import file
+      from oauth2client import tools
+  except ImportError:
+      raise ImportError('googleapiclient.sample_tools requires oauth2client. Please install oauth2client and try again.')
+
   if scope is None:
     scope = 'https://www.googleapis.com/auth/' + name
 

--- a/samples/maps_engine/maps_engine.py
+++ b/samples/maps_engine/maps_engine.py
@@ -47,8 +47,8 @@ import logging
 import sys
 import time
 
-from apiclient import sample_tools
-from apiclient.http import MediaFileUpload
+from googleapiclient import sample_tools
+from googleapiclient.http import MediaFileUpload
 
 logging.basicConfig(level=logging.INFO)
 

--- a/samples/prediction/prediction.py
+++ b/samples/prediction/prediction.py
@@ -39,12 +39,10 @@ __author__ = ('jcgregorio@google.com (Joe Gregorio), '
               'marccohen@google.com (Marc Cohen)')
 
 import argparse
-import os
 import pprint
 import sys
 import time
 
-from apiclient import discovery
 from apiclient import sample_tools
 from oauth2client import client
 


### PR DESCRIPTION
Prevent stray imports of older 'apiclient' alias from raising an ImportError if oauth2client is not installed, unless sample_tools.init is actually called.

Closes #524 
