### PR TITLE
Fix #164 under Python 3; prevent line-folding at beginning of content-id header

### DIFF
--- a/googleapiclient/http.py
+++ b/googleapiclient/http.py
@@ -1171,7 +1171,10 @@ class BatchHttpRequest(object):
     if self._base_id is None:
       self._base_id = uuid.uuid4()
 
-    return '<%s+%s>' % (self._base_id, quote(id_))
+    # NB: we intentionally leave whitespace between base/id and '+', so RFC2822
+    # line folding works properly on Python 3; see
+    # https://github.com/google/google-api-python-client/issues/164
+    return '<%s + %s>' % (self._base_id, quote(id_))
 
   def _header_to_id(self, header):
     """Convert a Content-ID header value to an id.
@@ -1192,7 +1195,7 @@ class BatchHttpRequest(object):
       raise BatchError("Invalid value for Content-ID: %s" % header)
     if '+' not in header:
       raise BatchError("Invalid value for Content-ID: %s" % header)
-    base, id_ = header[1:-1].rsplit('+', 1)
+    base, id_ = [x.strip() for x in header[1:-1].rsplit('+', 1)]
 
     return unquote(id_)
 

--- a/googleapiclient/http.py
+++ b/googleapiclient/http.py
@@ -1305,8 +1305,8 @@ class BatchHttpRequest(object):
         request id, and the second is the deserialized response object. The
         third is an googleapiclient.errors.HttpError exception object if an HTTP error
         occurred while processing the request, or None if no errors occurred.
-      request_id: string, A unique id for the request. The id will be passed to
-        the callback with the response.
+      request_id: string, A unique id for the request. The id will be passed
+        to the callback with the response.
 
     Returns:
       None

--- a/googleapiclient/http.py
+++ b/googleapiclient/http.py
@@ -1195,7 +1195,7 @@ class BatchHttpRequest(object):
       raise BatchError("Invalid value for Content-ID: %s" % header)
     if '+' not in header:
       raise BatchError("Invalid value for Content-ID: %s" % header)
-    base, id_ = [x.strip() for x in header[1:-1].rsplit('+', 1)]
+    base, id_ = [x.strip() for x in header[1:-1].split('+', 1)]
 
     return unquote(id_)
 
@@ -1306,7 +1306,9 @@ class BatchHttpRequest(object):
         third is an googleapiclient.errors.HttpError exception object if an HTTP error
         occurred while processing the request, or None if no errors occurred.
       request_id: string, A unique id for the request. The id will be passed to
-        the callback with the response.
+        the callback with the response.  It should not rely on beginning with
+        whitespace or ending with whitespace to make it unique; these will
+        be stripped in the response.
 
     Returns:
       None

--- a/googleapiclient/http.py
+++ b/googleapiclient/http.py
@@ -1195,7 +1195,7 @@ class BatchHttpRequest(object):
       raise BatchError("Invalid value for Content-ID: %s" % header)
     if '+' not in header:
       raise BatchError("Invalid value for Content-ID: %s" % header)
-    base, id_ = [x.strip() for x in header[1:-1].split('+', 1)]
+    base, id_ = header[1:-1].split(' + ', 1)
 
     return unquote(id_)
 
@@ -1306,9 +1306,7 @@ class BatchHttpRequest(object):
         third is an googleapiclient.errors.HttpError exception object if an HTTP error
         occurred while processing the request, or None if no errors occurred.
       request_id: string, A unique id for the request. The id will be passed to
-        the callback with the response.  It should not rely on beginning with
-        whitespace or ending with whitespace to make it unique; these will
-        be stripped in the response.
+        the callback with the response.
 
     Returns:
       None

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -635,7 +635,7 @@ ETag: "etag/pony"\r\n\r\n{"answer": 42}"""
 BATCH_RESPONSE = b"""--batch_foobarbaz
 Content-Type: application/http
 Content-Transfer-Encoding: binary
-Content-ID: <randomness+1>
+Content-ID: <randomness + 1>
 
 HTTP/1.1 200 OK
 Content-Type: application/json
@@ -645,7 +645,7 @@ ETag: "etag/pony"\r\n\r\n{"foo": 42}
 --batch_foobarbaz
 Content-Type: application/http
 Content-Transfer-Encoding: binary
-Content-ID: <randomness+2>
+Content-ID: <randomness + 2>
 
 HTTP/1.1 200 OK
 Content-Type: application/json
@@ -657,7 +657,7 @@ ETag: "etag/sheep"\r\n\r\n{"baz": "qux"}
 BATCH_ERROR_RESPONSE = b"""--batch_foobarbaz
 Content-Type: application/http
 Content-Transfer-Encoding: binary
-Content-ID: <randomness+1>
+Content-ID: <randomness + 1>
 
 HTTP/1.1 200 OK
 Content-Type: application/json
@@ -667,7 +667,7 @@ ETag: "etag/pony"\r\n\r\n{"foo": 42}
 --batch_foobarbaz
 Content-Type: application/http
 Content-Transfer-Encoding: binary
-Content-ID: <randomness+2>
+Content-ID: <randomness + 2>
 
 HTTP/1.1 403 Access Not Configured
 Content-Type: application/json
@@ -693,7 +693,7 @@ ETag: "etag/sheep"\r\n\r\n{
 BATCH_RESPONSE_WITH_401 = b"""--batch_foobarbaz
 Content-Type: application/http
 Content-Transfer-Encoding: binary
-Content-ID: <randomness+1>
+Content-ID: <randomness + 1>
 
 HTTP/1.1 401 Authorization Required
 Content-Type: application/json
@@ -704,7 +704,7 @@ ETag: "etag/pony"\r\n\r\n{"error": {"message":
 --batch_foobarbaz
 Content-Type: application/http
 Content-Transfer-Encoding: binary
-Content-ID: <randomness+2>
+Content-ID: <randomness + 2>
 
 HTTP/1.1 200 OK
 Content-Type: application/json
@@ -716,7 +716,7 @@ ETag: "etag/sheep"\r\n\r\n{"baz": "qux"}
 BATCH_SINGLE_RESPONSE = b"""--batch_foobarbaz
 Content-Type: application/http
 Content-Transfer-Encoding: binary
-Content-ID: <randomness+1>
+Content-ID: <randomness + 1>
 
 HTTP/1.1 200 OK
 Content-Type: application/json


### PR DESCRIPTION
Closes #164 

Closes #536

Also ensures that things don't break if a user supplies a request_id with a "+" in it.
