### PR TITLE
Return response synchronously if no callback was provided

### DIFF
--- a/googleapiclient/http.py
+++ b/googleapiclient/http.py
@@ -1480,7 +1480,7 @@ class BatchHttpRequest(object):
       except HttpError as e:
         exception = e
     
-      if request_id is not None:
+      if request_id is not None and response is not None:
         response['request_id'] = request_id
       
       results.append([response, exception])


### PR DESCRIPTION
It's useful to be able to get the results of a batch execute request within the scope of the function that's calling it, rather than asynchronously via a callback. This PR allows for that to happen if no callback exists. 