### PR TITLE
Fix HttpRequest json dump

### DIFF
--- a/googleapiclient/http.py
+++ b/googleapiclient/http.py
@@ -1030,6 +1030,7 @@ class HttpRequest(object):
     del d['postproc']
     del d['_sleep']
     del d['_rand']
+    del d['response_callbacks']
 
     return json.dumps(d)
 


### PR DESCRIPTION
Response callbacks are not JSON serializable and should be excluded from
json dump.